### PR TITLE
Feat : 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,14 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-devtools'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6:3.1.1.RELEASE'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'mysql:mysql-connector-java:8.0.32'
+	compileOnly 'org.projectlombok:lombok:1.18.26'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/cndinfo/config/MvcConfig.java
+++ b/src/main/java/com/cndinfo/config/MvcConfig.java
@@ -1,0 +1,23 @@
+package com.cndinfo.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class MvcConfig implements WebMvcConfigurer {
+	
+	@Override
+	public void addViewControllers(ViewControllerRegistry registry) {
+		
+		registry.addViewController("/").setViewName("index");
+		registry.addViewController("/home").setViewName("index");
+		registry.addViewController("/about").setViewName("about");
+		registry.addViewController("/services").setViewName("services");
+//		registry.addViewController("/contact").setViewName("contact");
+		registry.addViewController("/loginForm").setViewName("loginForm");
+		registry.addViewController("/join").setViewName("join");
+		
+	}
+
+}

--- a/src/main/java/com/cndinfo/controller/MainController.java
+++ b/src/main/java/com/cndinfo/controller/MainController.java
@@ -1,38 +1,5 @@
 package com.cndinfo.controller;
 
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-
-@Controller
 public class MainController {
-	
-	@GetMapping("/")
-	public String home() {
-		return "index";
-	}
 
-	@GetMapping("/about")
-	public String about() {
-		return "about";
-	}
-	
-	@GetMapping("/services")
-	public String services() {
-		return "services";
-	}
-	
-	@GetMapping("/contact")
-	public String contact() {
-		return "contact";
-	}
-	
-	@GetMapping("/login")
-	public String login() {
-		return "login";
-	}
-	
-	@GetMapping("/join")
-	public String join() {
-		return "join";
-	}
 }

--- a/src/main/java/com/cndinfo/controller/UserController.java
+++ b/src/main/java/com/cndinfo/controller/UserController.java
@@ -1,0 +1,49 @@
+package com.cndinfo.controller;
+
+import java.sql.SQLDataException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import com.cndinfo.domain.Alert;
+import com.cndinfo.domain.User;
+import com.cndinfo.service.UserService;
+import com.cndinfo.util.DateUtil;
+
+@Controller
+public class UserController {
+	
+	private static final Logger logger = LoggerFactory.getLogger(UserController.class);
+	
+	UserService userService;
+	DateUtil dateUtil;
+	
+	public UserController(UserService userService, DateUtil dateUtil) {
+		this.userService = userService;
+		this.dateUtil = dateUtil;
+	}
+	
+	@PostMapping("/user/save")
+	public String userSave(String name, String email, String pw, String telecom, String phone_number, Model model) {
+		String message = "";
+		String url = "";
+		try {
+			userService.userSave(new User(name, email, pw, telecom, phone_number, dateUtil.createDate(), null, "USER", "N'"));
+			logger.info("회원 정보 저장 완료");
+			message = "회원 가입이 완료되었습니다.";
+			url = "/";
+		} catch(SQLDataException e) {
+			logger.warn("이미 Email이 존재합니다.");
+			message = "이미 Email이 존재합니다.";
+			url = "/join";
+		} finally {
+			model.addAttribute("params", new Alert(message, url));
+		}
+		
+		return "common/alert.html";
+	}
+	
+}

--- a/src/main/java/com/cndinfo/domain/Alert.java
+++ b/src/main/java/com/cndinfo/domain/Alert.java
@@ -1,0 +1,12 @@
+package com.cndinfo.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+public class Alert {
+	
+	public String message;
+	public String redirectUrl;
+}

--- a/src/main/java/com/cndinfo/domain/User.java
+++ b/src/main/java/com/cndinfo/domain/User.java
@@ -1,0 +1,44 @@
+package com.cndinfo.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "user")
+public class User {
+	
+	@Id
+	public String name;
+	public String email;
+	public String pw;
+	public String telecom;
+	public String phone_number;
+	public String join_date;
+	public String dead_date = null;
+	public String role;
+	public String isCerti;
+
+	public User() {
+		
+	}
+	
+	public User(String name, String email, String pw, String telecom, String phone_number, String join_date,
+			String dead_date, String role, String isCerti) {
+		super();
+		this.name = name;
+		this.email = email;
+		this.telecom = telecom;
+		this.phone_number = phone_number;
+		this.pw = pw;
+		this.join_date = join_date;
+		this.dead_date = dead_date==null?null:dead_date;
+		this.role = role;
+		this.isCerti = "N";
+	}
+	
+	
+
+}

--- a/src/main/java/com/cndinfo/repository/UserRepository.java
+++ b/src/main/java/com/cndinfo/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.cndinfo.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.cndinfo.domain.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long>{
+	Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/cndinfo/service/UserService.java
+++ b/src/main/java/com/cndinfo/service/UserService.java
@@ -1,0 +1,27 @@
+package com.cndinfo.service;
+
+import java.sql.SQLDataException;
+
+import org.springframework.stereotype.Service;
+
+import com.cndinfo.domain.User;
+import com.cndinfo.repository.UserRepository;
+
+@Service
+public class UserService {
+	
+	UserRepository userRepo;
+	
+	public UserService(UserRepository userRepo) {
+		this.userRepo = userRepo;
+	}
+	
+	public void userSave(User user) throws SQLDataException {
+		if(userRepo.findByEmail(user.getEmail()) == null) {
+			userRepo.save(user);
+		} else {
+			new SQLDataException();
+		}
+	}
+
+}

--- a/src/main/java/com/cndinfo/util/DateUtil.java
+++ b/src/main/java/com/cndinfo/util/DateUtil.java
@@ -1,0 +1,19 @@
+package com.cndinfo.util;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class DateUtil {
+	
+	// Make Date
+	public String createDate() {
+		
+		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+		
+		return sdf.format(new Date());
+	}
+
+}

--- a/src/main/resources/templates/common/alert.html
+++ b/src/main/resources/templates/common/alert.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+	<th:block th:if="${#strings.length(params.message) != 0}">
+		<script>
+			top.alert("[[${params.message}]]");
+		</script>
+	</th:block>
+	<th:block th:if="${#strings.length(params.redirectUrl) != 0}">
+		<script>
+			top.location.href = '[[${params.redirectUrl}]]';
+		</script>
+	</th:block>
+</head>
+</html>

--- a/src/main/resources/templates/join.html
+++ b/src/main/resources/templates/join.html
@@ -43,11 +43,15 @@
                     <h1 class="contact_text">Join</h1>
                     <div class="contact_main">
                         <div class="mail_section">
-                        	<form th:action="user_save" th:method="POST">
-	                        	<input type="Name" class="mail_text" placeholder="Name" name="namve">
-	                            <input type="Name" class="mail_text" placeholder="Email" name="email">
-	                            <input type="Name" class="mail_text" placeholder="Password" name="password">
-                        	</form>
+                        	<form th:action="@{/user/save}" th:method="POST">
+	                        	<input class="mail_text" placeholder="Name" name="name">
+	                            <input class="mail_text" placeholder="Email" name="email">
+	                            <input type="password" class="mail_text" placeholder="Password" name="pw">
+	                            <input class="mail_text" placeholder="telecom" name="telecom">
+	                            <input class="mail_text" placeholder="phone" name="phone">
+	                            <button class="mail_text">저장</button>
+                            </form>
+                        	<a data-th-href="@{/}"><button class="mail_text" >홈으로</button></a>
                         </div>
                     </div>
                 </div>

--- a/src/main/resources/templates/loginForm.html
+++ b/src/main/resources/templates/loginForm.html
@@ -42,11 +42,13 @@
                 <div class="col-md-6">
                     <h1 class="contact_text">Login</h1>
                     <div class="contact_main">
-                        <div class="mail_section">
-                            <input type="Name" class="mail_text" placeholder="Name" name="Name">
-                            <input type="Name" class="mail_text" placeholder="Email" name="Email">
-                            <input type="Name" class="mail_text" placeholder="Password" name="Password">
-                        </div>
+                    	<form th:action="@{/login}", th:method="POST">
+	                        <div class="mail_section">
+	                            <input type="Name" class="mail_text" placeholder="Email" name="email">
+	                            <input type="Password" class="mail_text" placeholder="Password" name="pw">
+	                        </div>
+	                        <input type="submit" class="mail_text" value="Sign In"/>
+                        </form>
                         <div>
                         	<button class="mail_text" th:onclick="|location.href='@{/join}'|" th:text="회원가입"></button>
                         </div>


### PR DESCRIPTION
User 정보들은 화면에서 전달받은 후 해당 User의 Email을 토대로 존재하는 회원인지 판단한 후 회원가입 진행. 회원가입 페이지에서 SMS 인증 기능을 적용하고 싶었지만 버튼 클릭 시 화면 데이터를 유지해야 하며 화면 이동이 이루어지지 않는 채로 SMS 발송 로직이 이루어져야 된다는 점에서 해결방법 찾지 못하였음. 현재로써는 다른 페이지에서 인증을 진행한 후 추후에 통합해야할 것 같음.

Resolves: #2
See Alse : #6