### PR TITLE
Feat : Membership 크롤링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,17 +15,25 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-devtools'
+	// Spring Security 관련 라이브러리
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6:3.1.1.RELEASE'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.security:spring-security-test'
-	implementation 'org.springframework.boot:spring-boot-devtools'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6:3.1.1.RELEASE'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'mysql:mysql-connector-java:8.0.32'
+	// JSON 객체 라이브러리
 	implementation 'org.json:json:20230618'
+	// DataBase 관련 라이브러리
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'mysql:mysql-connector-java:8.0.32'
+	// Redis 라이브러리
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// HTTP 통신을 위한 라이브러리
 	implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
 	implementation 'org.apache.httpcomponents:httpclient:4.5.14'
+	// 메일 발송 라이브러리
 	implementation 'org.springframework.boot:spring-boot-starter-mail:2.5.4'
+	// 웹 크롤링 관련 라이브러리
+	implementation 'org.jsoup:jsoup:1.16.1'
 	compileOnly 'org.projectlombok:lombok:1.18.26'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/cndinfo/config/WebSecurityConfig.java
+++ b/src/main/java/com/cndinfo/config/WebSecurityConfig.java
@@ -28,6 +28,8 @@ public class WebSecurityConfig {
 				.requestMatchers("/user/save").permitAll()
 				// 해당 request에서는 "USER" 역할을 가진 유저에게만 허용한다.
 				.requestMatchers("/certi", "/certi/**", "/certification", "/user/modify").hasAuthority("USER")
+				// membership 페이지 접근은 USER 권한을 가진 유저에게만 허용한다.
+				.requestMatchers("/memebership/**").hasAuthority("USER")
 				// ADMIN, UER 역할일 경우에만 접속가능하도록 설정. 역할이 부여되지 않았을 때에는 접속 하지 못하도록 하기 위해서 permitAll() 설정은 하지 않았음. 
 				.requestMatchers("/mypage", "/checkpw", "/user/checkpw").hasAnyAuthority("ADMIN", "USER")
 			).formLogin((form) -> form

--- a/src/main/java/com/cndinfo/repository/MembershipRepository.java
+++ b/src/main/java/com/cndinfo/repository/MembershipRepository.java
@@ -1,0 +1,5 @@
+package com.cndinfo.repository;
+
+public interface MembershipRepository {
+
+}

--- a/src/main/java/com/cndinfo/service/MembershipService.java
+++ b/src/main/java/com/cndinfo/service/MembershipService.java
@@ -1,0 +1,5 @@
+package com.cndinfo.service;
+
+public class MembershipService {
+
+}

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -19,7 +19,14 @@
 		              <a class="nav-link" href="/services">SERVICES</a>
 		            </li>
 		            <li class="nav-item">
-		              <a class="nav-link" href="/coupon">COUPON</a>
+		              <div class="dropdown" sec:authorize="isAuthenticated()" >
+  							<span class="dropbtn">MEMBERSHIP</span>
+							<div class="dropdown-contents">
+							    <a href="/membership/skt">SKT</a>
+							    <a href="/membership/kt">KT</a>
+							    <a href="/membership/lg">LG U+</a>
+							</div>
+						</div>
 		            </li>
 		            <li class="nav-item">
 		              <a class="nav-link" href="/discount">DISCOUNT</a>

--- a/src/test/java/com/cndinfo/service/MembershipServiceTest.java
+++ b/src/test/java/com/cndinfo/service/MembershipServiceTest.java
@@ -1,0 +1,23 @@
+package com.cndinfo.service;
+
+import java.io.IOException;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.annotation.Testable;
+
+@Testable
+public class MembershipServiceTest {
+	
+	@Test
+	public void sktTest() throws IOException {
+		
+		String url = "https://sktmembership.tworld.co.kr/mps/pc-bff/benefitbrand/list-tab1.do";
+		
+		Document doc = Jsoup.connect(url).get();
+		
+		System.out.println(doc.getAllElements());
+	}
+
+}


### PR DESCRIPTION
SKT 멤버십 크롤링 하기 위해 jsoup 을 사용하여 크롤이 해보았지만 다음과 같은 문제점이 존재하였음.

1. SKT 멤버십 중 혜택 브랜드 페이지는 DataBase 페이징 처리가 되어 있는 것 같음.( -> 다른 페이지로 이동하여도 url 자체는 동일함. )
2. 개발 진행을 위해 직접 DataBase에 insert 한다고 하더라도 DataBase 페이징 처리 때문에 1페이지가 아닌 다른 페이지의 정보를 가져오는 것을 진행하지 못 함. ( 다른 페이지의 정보를 어떻게 가져올지에 대한 방안 필요. )

See Also : #8