### PR TITLE
Feat : 브랜드 id 뽑아내기

### DIFF
--- a/docs/MembershipTest/SKTTest.html
+++ b/docs/MembershipTest/SKTTest.html
@@ -1,0 +1,8147 @@
+<!doctype html>
+<html lang="ko">
+ <head>
+  <title>T 멤버십</title>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Type" content="text/html">
+  <meta http-equiv="Content-Script-Type" content="text/javascript">
+  <meta http-equiv="Content-Style-Type" content="text/css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, viewport-fit=cover">
+  <meta http-equiv="X-UA-compatible" content="IE=edge,chrome=1">
+  <link rel="shortcut icon" href="https://cdn.sktmembership.co.kr/mps.pc/favicon.ico" type="image/x-icon">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/poc/inc/css/footer.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/jquery-ui.min.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/swiper.min.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/common.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/style.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/wait.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/benefit.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/re_gnb.css">
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-3.4.1.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-ui.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/swiper.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/common.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/promise-polyfill.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/common/jsrender.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/axios.min.js"></script>
+  <script>
+        var CDN_PATH = "https:\/\/cdn.sktmembership.co.kr\/mps.pc";
+        var ENV = "prd";
+        var IS_LOGIN = false;
+        var IS_MBR_CARD = false;
+    </script>
+  <script type="text/javascript" src="/js/common-4c70bc9059822c175d8f8e59ac010eef.js"></script>
+  <script type="text/javascript" src="/js/netfunnel-194808761f66576464c07f70ba55a195.js"></script><!--     <link rel="stylesheet" type="text/css" th:href="@{${_config.url('/poc/gnb/inc/css/gnb.css')}}"> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/js/jquery.gnb.js')}}"></script> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/js/gnb.js')}}"></script> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/cmn/gnb_cmn.js')}}"></script> --> <!-- 	<script type="text/javascript" th:src="@{'/poc/gnb/inc/cmn/re_gnb.js'}"></script> -->
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/js/re_gnb.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/cmn/common_url_new.js"></script>
+  <script src="https://xtr.tos.sktelecom.com/js/xtractor_script.js"></script>
+ </head>
+ <body>
+  <div class="accessbility">
+   <a href="#content">본문 바로가기</a>
+  </div>
+  <div class="wrap" id="wrap">
+   <!--<div id="header"></div>-->
+   <div id="header" class="main-header">
+    <input id="envUrl" hidden value="https://www.tworld.co.kr">
+    <div class="main-header__inner">
+     <!-- header 상단 기본 -->
+     <div class="main-header__top">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__logo">
+        <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+       </div>
+       <div class="main-header__util-item" id="gnb_login">
+        <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+        <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+       </div>
+       <div class="main-header__family-site family-list">
+        <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+       </div>
+      </div>
+     </div><!-- // header 상단 기본 --> <!-- GNB 기본 -->
+     <div class="main-header__bottom">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu gnb">
+        <!-- 활성화된 메뉴의 a 태그에 is-active -->
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+        </div>
+       </div>
+       <div class="main-header__util header-util">
+        <div class="header-util__item">
+         <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB 기본 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T membership main --> <!-- 혜택 브랜드 --> <!-- 20230414 2depth 삭제 --> <!-- GNB 서브페이지 (상품서비스) -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+        </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+       </div>
+      </div>
+     </div><!-- // GNB 서브페이지 (my) --> <!-- //20230414 2depth 삭제 --> <!-- //혜택 브랜드 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 혜택 프로그램 --> <!-- GNB Family menu -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB Family menu --> <!-- //혜택 프로그램 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 나의 T 멤버십 --> <!-- GNB Family menu -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB Family menu --> <!-- //나의 T 멤버십 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T 멤버십 안내 --> <!-- GNB Family menu -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB Family menu --> <!-- //T 멤버십 안내 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> -->
+    </div>
+   </div>
+   <div class="container">
+    <div id="content">
+     <div class="inr-wrap">
+      <div class="title-area">
+       <h1>배스킨라빈스</h1><input type="hidden" name="brandId" id="brandId" value="998"> <input type="hidden" name="brandName" id="brandName" value="배스킨라빈스">
+      </div><!-- 브랜드 상단 영역 -->
+      <div class="brnad-info-top">
+       <div class="bit-left">
+        <p class="tit">행복을 전하는 프리미엄 아이스크림, 배스킨라빈스</p>
+        <div class="badge-list">
+         <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+        </div>
+       </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202204/1649135025498.png" alt="배스킨라빈스"> </span>
+      </div><!-- //브랜드 상단 영역 --> <!-- 브랜드 선택 영역 -->
+      <div class="brand-sel-box">
+       <div class="fc-select">
+        <span>고객님이 선택하신 브랜드는</span>
+        <div class="dropdown" data-selectbox>
+         <a href="javascript:;" data-set-button> <span></span></a>
+         <div data-set-list>
+          <ul id="sel-ul">
+           <!-- 선택된 값에 'data-selected' 추가 -->
+           <li id="53"><a>베이커리</a></li>
+           <li id="54"><a>외식</a></li>
+           <li id="55" data-selected="data-selected"><a>카페/아이스크림</a></li>
+           <li id="56"><a>피자/치킨</a></li>
+           <li id="48"><a>금융/통신</a></li>
+           <li id="112"><a>렌탈</a></li>
+           <li id="116"><a>반려동물</a></li>
+           <li id="49"><a>생활/교통</a></li>
+           <li id="50"><a>쇼핑몰</a></li>
+           <li id="51"><a>패션/뷰티</a></li>
+           <li id="52"><a>편의점</a></li>
+           <li id="57"><a>교육</a></li>
+           <li id="109"><a>액티비티</a></li>
+           <li id="59"><a>여행</a></li>
+           <li id="60"><a>영화/공연/전시</a></li>
+           <li id="61"><a>콘텐츠</a></li>
+           <li id="110"><a>테마파크</a></li>
+          </ul>
+         </div>
+        </div>
+        <div class="dropdown" data-selectbox>
+         <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+         <div id="smallList" data-set-list>
+          <ul id="sel-list">
+           <li id="998" data-selected="data-selected"><a>배스킨라빈스</a></li>
+           <li id="771"><a>공차</a></li>
+           <li id="67"><a>폴 바셋</a></li>
+           <li id="992"><a>던킨</a></li>
+           <li id="887"><a>엔제리너스</a></li>
+           <li id="5051"><a>드롭탑</a></li>
+           <li id="961"><a>나뚜루&amp;나뚜루시그니처 </a></li>
+           <li id="1093"><a>미스터힐링</a></li>
+          </ul>
+         </div>
+        </div><span>입니다.</span>
+       </div>
+      </div><!-- //브랜드 선택 영역 --> <!-- 브랜드 상세 혜택 소개 영역 -->
+      <div class="brand-detail">
+       <div class="bd-top">
+        <div class="cate">
+         <span>EAT </span> <span>카페/아이스크림</span> <input type="hidden" name="categoryMid" id="categoryMid" value="55"> <input type="hidden" name="categoryMname" id="categoryMname" value="카페/아이스크림">
+        </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">149819</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="149819"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+       </div>
+       <div class="detail-list">
+        <dl>
+         <dt>
+          혜택
+         </dt>
+         <dd>
+          <dl class="dl-bnf">
+           <dt>
+            할인형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 할인(2,000원)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 할인(1,200원)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+          <dl class="dl-bnf">
+           <dt>
+            적립형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 적립(2,000P)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 적립(1,200P)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+         </dd>
+        </dl>
+        <dl>
+         <dt>
+          유의사항
+         </dt>
+         <dd>
+          <div class="notice">
+           <div class="explain-area pd-no">
+            <ul class="list-dot">
+             <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+             <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+             <li>대상 상품: 싱글레귤러(콘/컵 및 맛 선택 가능, 포장 안 됨)</li>
+             <li>횟수 제한 <br>
+              -할인: 월 1회, 싱글레귤러 1개 <br>
+              -적립: 월 1회, 싱글레귤러 1개 <br>
+              -포인트 사용: T 플러스포인트는 보유하신 한도 내에서 싱글레귤러 주문 시 횟수/수량 제한 없이 사용 가능</li>
+             <li>최대 할인 가능: VIP 2,000원, GOLD/SILVER 1,200원 할인</li>
+             <li>최대 적립 가능: VIP 2,000P, GOLD/SILVER 1,200P 적립</li>
+             <li>다른 행사 및 쿠폰, 제휴 할인과 중복 적용되지 않음</li>
+             <li>할인/적립/사용 금액 제외한 결제 금액의 0.1% 해피포인트 적립</li>
+             <li>모바일 교환권 사용 가능(단, 할인된 모바일 교환권은 사용할 수 없음)</li>
+             <li>매장에 방문하여 현장 구매 시 이용 가능(모바일 주문 및 배달 시 이용할 수 없음)</li>
+             <li>일부 매장 제외 (방문 전 매장 문의 및 배스킨라빈스 홈페이지 참조)</li>
+             <li>적립된 T 플러스포인트는 ‘적립 예정’ 포인트로 표시되며, 결제한 다음 날부터 사용 가능 포인트로 전환</li>
+             <li class="web-link"><a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a></li>
+             <li class="app-link"><a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a></li>
+            </ul>
+           </div>
+          </div>
+         </dd>
+        </dl>
+        <dl>
+         <dt>
+          문의 및 상담
+         </dt>
+         <dd>
+          <ul class="list-dash">
+           <li>TEL : 080-555-3131</li>
+           <li>HOME : <a href="javascript:goHomePage('')"></a></li>
+          </ul>
+         </dd>
+        </dl>
+       </div>
+      </div>
+     </div><!-- //브랜드 상세 혜택 소개 영역 --> <!-- 비슷한 혜택 브랜드 추천 영역 -->
+     <div class="similar-area">
+      <div class="inr-wrap">
+       <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+       <ul class="benefit-list">
+        <li><a href="javascript:;" class="benefit-box" id="67" data-title="폴 바셋" data-idx="0" data-cate-id="55" data-cate-name="카페/아이스크림">
+          <div class="bnf-top">
+           <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202211/1667888724269.png" alt="폴 바셋"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">폴 바셋</span>
+           <div class="badge-list">
+            <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+           </div>
+          </div>
+          <div class="bnf-info">
+           <dl class="dl-bnf">
+            <dt>
+             할인형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종(사이즈 무관) 구매 시 10% 할인
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+           <dl class="dl-bnf">
+            <dt>
+             적립형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피(사이즈 무관) 구매 시 10% 적립
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+          </div><span class="btn-round gra">자세히 보기</span> </a></li>
+        <li><a href="javascript:;" class="benefit-box" id="1093" data-title="미스터힐링" data-idx="1" data-cate-id="55" data-cate-name="카페/아이스크림">
+          <div class="bnf-top">
+           <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635300553816.png" alt="미스터힐링"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">미스터힐링</span>
+           <div class="badge-list">
+            <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+           </div>
+          </div>
+          <div class="bnf-info">
+           <dl class="dl-bnf">
+            <dt>
+             할인형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 할인
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+           <dl class="dl-bnf">
+            <dt>
+             적립형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 적립
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+          </div><span class="btn-round gra">자세히 보기</span> </a></li>
+        <li><a href="javascript:;" class="benefit-box" id="992" data-title="던킨" data-idx="2" data-cate-id="55" data-cate-name="카페/아이스크림">
+          <div class="bnf-top">
+           <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202203/1648185466264.png" alt="던킨"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">던킨</span>
+           <div class="badge-list">
+            <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+           </div>
+          </div>
+          <div class="bnf-info">
+           <dl class="dl-bnf">
+            <dt>
+             할인형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 할인
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 할인
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+           <dl class="dl-bnf">
+            <dt>
+             적립형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 적립
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 적립
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+          </div><span class="btn-round gra">자세히 보기</span> </a></li>
+       </ul>
+      </div>
+     </div><!-- //비슷한 혜택 브랜드 추천 영역 -->
+    </div>
+   </div><!--         <div id="footer"></div> -->
+   <div id="footer" class="main-footer">
+    <a href="#" class="footer__go-top"><span class="hidden">상단으로 이동</span></a>
+    <div class="main-footer__top">
+     <div class="footer_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="bar-list">
+       <div class="bar-list__item">
+        <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+       </div><!-- 2023-05-23 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+       </div><!-- 2023-05-23 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+       </div>
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+       </div>
+       <div class="bar-list__item">
+        <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+       </div>
+      </div>
+     </div>
+    </div>
+    <div class="main-footer__bottom">
+     <div class="footer_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="logo-list">
+       <div class="logo-list__item">
+        <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+          26년 연속 1위</span></a>
+       </div><!-- 2023-05-30 수정 -->
+       <div class="logo-list__item">
+        <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+          23년 연속 1위</span></a>
+       </div><!-- 20230508 수정 -->
+       <div class="logo-list__item">
+        <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+          25년 연속 1위</span></a>
+       </div><!-- 20230508 수정 -->
+       <div class="logo-list__item">
+        <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+       </div><!-- 20230508 수정 -->
+      </div>
+      <div class="footer__info-box width-auto">
+       <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+       <div class="column-box__item">
+        <div class="column-box__inner">
+         <div class="bar-list bar-list--narrow">
+          <div class="bar-list__item">
+           SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+           <br>
+           (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+          </div>
+          <hr class="bar-list--narrow bar-list--grey">
+          <div class="bar-list__item">
+           <strong>고객센터</strong>
+          </div>
+          <div class="bar-list__item">
+           대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+          </div><!-- 2023-05-23 수정 -->
+          <hr class="bar-list__line">
+          <div class="bar-list__item">
+           인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+          </div><!-- 2023-05-23 수정 -->
+          <div class="bar-list__item">
+           T 멤버십 마켓 : 1599-3377(유료)
+          </div><!-- 2023-05-23 수정 -->
+         </div>
+         <div class="bar-list bar-list--narrow bar-list--grey">
+          <div class="bar-list__item">
+           대표이사/사장 : 유영상
+          </div>
+          <div class="bar-list__item">
+           사업자등록번호 : 104-81-37225
+          </div>
+          <div class="bar-list__item">
+           판매허가번호 : 중구 02923호
+          </div>
+          <div class="bar-list__item">
+           <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+          </div>
+          <hr class="bar-list__line">
+          <div class="bar-list__item">
+           서울특별시 중구 을지로 65
+          </div>
+          <hr class="bar-list__line">
+          <div class="bar-list__item copyright">
+           COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+          </div>
+         </div>
+        </div>
+       </div>
+       <div class="column-box__item column-box__item--right">
+        <div class="column-box__inner">
+         <div class="site-list">
+          <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+          <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+           <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+           <div class="family-list" data-element="commonToggle__layer">
+            <div class="family-list__item">
+             <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+            </div><!-- 2023-05-30 수정 -->
+            <div class="family-list__item">
+             <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+            </div>
+            <div class="family-list__item">
+             <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+            </div>
+            <div class="family-list__item">
+             <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+            </div>
+           </div>
+          </div>
+         </div>
+         <div class="social-list">
+          <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+         </div>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+   <script type="text/javascript" src="/js/benefitbrand/MPW_D001_P03-f38ad4ae8f7e63be2335a3a34ed7a5af.js"></script>
+  </div>
+  <div class="toast01" data-toast="toastContainer" data-y="bottom" data-duration="800" data-pos="20" data-timer="3000">
+   <span id="toastContainer"></span>
+  </div>
+  <div class="loadingbar-area"></div>
+ </body>
+</html>
+<html lang="ko">
+ <head>
+  <title>T 멤버십</title>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Type" content="text/html">
+  <meta http-equiv="Content-Script-Type" content="text/javascript">
+  <meta http-equiv="Content-Style-Type" content="text/css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, viewport-fit=cover">
+  <meta http-equiv="X-UA-compatible" content="IE=edge,chrome=1">
+  <link rel="shortcut icon" href="https://cdn.sktmembership.co.kr/mps.pc/favicon.ico" type="image/x-icon">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/poc/inc/css/footer.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/jquery-ui.min.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/swiper.min.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/common.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/style.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/wait.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/benefit.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/re_gnb.css">
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-3.4.1.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-ui.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/swiper.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/common.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/promise-polyfill.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/common/jsrender.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/axios.min.js"></script>
+  <script>
+        var CDN_PATH = "https:\/\/cdn.sktmembership.co.kr\/mps.pc";
+        var ENV = "prd";
+        var IS_LOGIN = false;
+        var IS_MBR_CARD = false;
+    </script>
+  <script type="text/javascript" src="/js/common-4c70bc9059822c175d8f8e59ac010eef.js"></script>
+  <script type="text/javascript" src="/js/netfunnel-194808761f66576464c07f70ba55a195.js"></script><!--     <link rel="stylesheet" type="text/css" th:href="@{${_config.url('/poc/gnb/inc/css/gnb.css')}}"> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/js/jquery.gnb.js')}}"></script> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/js/gnb.js')}}"></script> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/cmn/gnb_cmn.js')}}"></script> --> <!-- 	<script type="text/javascript" th:src="@{'/poc/gnb/inc/cmn/re_gnb.js'}"></script> -->
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/js/re_gnb.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/cmn/common_url_new.js"></script>
+  <script src="https://xtr.tos.sktelecom.com/js/xtractor_script.js"></script>
+ </head>
+ <body>
+  <div class="accessbility">
+   <a href="#content">본문 바로가기</a>
+  </div>
+  <div class="wrap" id="wrap">
+   <!--<div id="header"></div>-->
+   <div id="header" class="main-header">
+    <input id="envUrl" hidden value="https://www.tworld.co.kr">
+    <div class="main-header__inner">
+     <!-- header 상단 기본 -->
+     <div class="main-header__top">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__logo">
+        <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+       </div>
+       <div class="main-header__util-item" id="gnb_login">
+        <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+        <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+       </div>
+       <div class="main-header__family-site family-list">
+        <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+       </div>
+      </div>
+     </div><!-- // header 상단 기본 --> <!-- GNB 기본 -->
+     <div class="main-header__bottom">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu gnb">
+        <!-- 활성화된 메뉴의 a 태그에 is-active -->
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+        </div>
+       </div>
+       <div class="main-header__util header-util">
+        <div class="header-util__item">
+         <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB 기본 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T membership main --> <!-- 혜택 브랜드 --> <!-- 20230414 2depth 삭제 --> <!-- GNB 서브페이지 (상품서비스) -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+        </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+       </div>
+      </div>
+     </div><!-- // GNB 서브페이지 (my) --> <!-- //20230414 2depth 삭제 --> <!-- //혜택 브랜드 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 혜택 프로그램 --> <!-- GNB Family menu -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB Family menu --> <!-- //혜택 프로그램 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 나의 T 멤버십 --> <!-- GNB Family menu -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB Family menu --> <!-- //나의 T 멤버십 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T 멤버십 안내 --> <!-- GNB Family menu -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB Family menu --> <!-- //T 멤버십 안내 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> -->
+    </div>
+   </div>
+   <div class="container">
+    <div id="content">
+     <div class="inr-wrap">
+      <div class="title-area">
+       <h1>배스킨라빈스</h1><input type="hidden" name="brandId" id="brandId" value="998"> <input type="hidden" name="brandName" id="brandName" value="배스킨라빈스">
+      </div><!-- 브랜드 상단 영역 -->
+      <div class="brnad-info-top">
+       <div class="bit-left">
+        <p class="tit">행복을 전하는 프리미엄 아이스크림, 배스킨라빈스</p>
+        <div class="badge-list">
+         <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+        </div>
+       </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202204/1649135025498.png" alt="배스킨라빈스"> </span>
+      </div><!-- //브랜드 상단 영역 --> <!-- 브랜드 선택 영역 -->
+      <div class="brand-sel-box">
+       <div class="fc-select">
+        <span>고객님이 선택하신 브랜드는</span>
+        <div class="dropdown" data-selectbox>
+         <a href="javascript:;" data-set-button> <span></span></a>
+         <div data-set-list>
+          <ul id="sel-ul">
+           <!-- 선택된 값에 'data-selected' 추가 -->
+           <li id="53"><a>베이커리</a></li>
+           <li id="54"><a>외식</a></li>
+           <li id="55" data-selected="data-selected"><a>카페/아이스크림</a></li>
+           <li id="56"><a>피자/치킨</a></li>
+           <li id="48"><a>금융/통신</a></li>
+           <li id="112"><a>렌탈</a></li>
+           <li id="116"><a>반려동물</a></li>
+           <li id="49"><a>생활/교통</a></li>
+           <li id="50"><a>쇼핑몰</a></li>
+           <li id="51"><a>패션/뷰티</a></li>
+           <li id="52"><a>편의점</a></li>
+           <li id="57"><a>교육</a></li>
+           <li id="109"><a>액티비티</a></li>
+           <li id="59"><a>여행</a></li>
+           <li id="60"><a>영화/공연/전시</a></li>
+           <li id="61"><a>콘텐츠</a></li>
+           <li id="110"><a>테마파크</a></li>
+          </ul>
+         </div>
+        </div>
+        <div class="dropdown" data-selectbox>
+         <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+         <div id="smallList" data-set-list>
+          <ul id="sel-list">
+           <li id="998" data-selected="data-selected"><a>배스킨라빈스</a></li>
+           <li id="771"><a>공차</a></li>
+           <li id="67"><a>폴 바셋</a></li>
+           <li id="992"><a>던킨</a></li>
+           <li id="887"><a>엔제리너스</a></li>
+           <li id="5051"><a>드롭탑</a></li>
+           <li id="961"><a>나뚜루&amp;나뚜루시그니처 </a></li>
+           <li id="1093"><a>미스터힐링</a></li>
+          </ul>
+         </div>
+        </div><span>입니다.</span>
+       </div>
+      </div><!-- //브랜드 선택 영역 --> <!-- 브랜드 상세 혜택 소개 영역 -->
+      <div class="brand-detail">
+       <div class="bd-top">
+        <div class="cate">
+         <span>EAT </span> <span>카페/아이스크림</span> <input type="hidden" name="categoryMid" id="categoryMid" value="55"> <input type="hidden" name="categoryMname" id="categoryMname" value="카페/아이스크림">
+        </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">149819</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="149819"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+       </div>
+       <div class="detail-list">
+        <dl>
+         <dt>
+          혜택
+         </dt>
+         <dd>
+          <dl class="dl-bnf">
+           <dt>
+            할인형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 할인(2,000원)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 할인(1,200원)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+          <dl class="dl-bnf">
+           <dt>
+            적립형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 적립(2,000P)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 적립(1,200P)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+         </dd>
+        </dl>
+        <dl>
+         <dt>
+          유의사항
+         </dt>
+         <dd>
+          <div class="notice">
+           <div class="explain-area pd-no">
+            <ul class="list-dot">
+             <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+             <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+             <li>대상 상품: 싱글레귤러(콘/컵 및 맛 선택 가능, 포장 안 됨)</li>
+             <li>횟수 제한 <br>
+              -할인: 월 1회, 싱글레귤러 1개 <br>
+              -적립: 월 1회, 싱글레귤러 1개 <br>
+              -포인트 사용: T 플러스포인트는 보유하신 한도 내에서 싱글레귤러 주문 시 횟수/수량 제한 없이 사용 가능</li>
+             <li>최대 할인 가능: VIP 2,000원, GOLD/SILVER 1,200원 할인</li>
+             <li>최대 적립 가능: VIP 2,000P, GOLD/SILVER 1,200P 적립</li>
+             <li>다른 행사 및 쿠폰, 제휴 할인과 중복 적용되지 않음</li>
+             <li>할인/적립/사용 금액 제외한 결제 금액의 0.1% 해피포인트 적립</li>
+             <li>모바일 교환권 사용 가능(단, 할인된 모바일 교환권은 사용할 수 없음)</li>
+             <li>매장에 방문하여 현장 구매 시 이용 가능(모바일 주문 및 배달 시 이용할 수 없음)</li>
+             <li>일부 매장 제외 (방문 전 매장 문의 및 배스킨라빈스 홈페이지 참조)</li>
+             <li>적립된 T 플러스포인트는 ‘적립 예정’ 포인트로 표시되며, 결제한 다음 날부터 사용 가능 포인트로 전환</li>
+             <li class="web-link"><a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a></li>
+             <li class="app-link"><a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a></li>
+            </ul>
+           </div>
+          </div>
+         </dd>
+        </dl>
+        <dl>
+         <dt>
+          문의 및 상담
+         </dt>
+         <dd>
+          <ul class="list-dash">
+           <li>TEL : 080-555-3131</li>
+           <li>HOME : <a href="javascript:goHomePage('')"></a></li>
+          </ul>
+         </dd>
+        </dl>
+       </div>
+      </div>
+     </div><!-- //브랜드 상세 혜택 소개 영역 --> <!-- 비슷한 혜택 브랜드 추천 영역 -->
+     <div class="similar-area">
+      <div class="inr-wrap">
+       <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+       <ul class="benefit-list">
+        <li><a href="javascript:;" class="benefit-box" id="67" data-title="폴 바셋" data-idx="0" data-cate-id="55" data-cate-name="카페/아이스크림">
+          <div class="bnf-top">
+           <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202211/1667888724269.png" alt="폴 바셋"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">폴 바셋</span>
+           <div class="badge-list">
+            <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+           </div>
+          </div>
+          <div class="bnf-info">
+           <dl class="dl-bnf">
+            <dt>
+             할인형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종(사이즈 무관) 구매 시 10% 할인
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+           <dl class="dl-bnf">
+            <dt>
+             적립형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피(사이즈 무관) 구매 시 10% 적립
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+          </div><span class="btn-round gra">자세히 보기</span> </a></li>
+        <li><a href="javascript:;" class="benefit-box" id="1093" data-title="미스터힐링" data-idx="1" data-cate-id="55" data-cate-name="카페/아이스크림">
+          <div class="bnf-top">
+           <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635300553816.png" alt="미스터힐링"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">미스터힐링</span>
+           <div class="badge-list">
+            <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+           </div>
+          </div>
+          <div class="bnf-info">
+           <dl class="dl-bnf">
+            <dt>
+             할인형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 할인
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+           <dl class="dl-bnf">
+            <dt>
+             적립형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 적립
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+          </div><span class="btn-round gra">자세히 보기</span> </a></li>
+        <li><a href="javascript:;" class="benefit-box" id="992" data-title="던킨" data-idx="2" data-cate-id="55" data-cate-name="카페/아이스크림">
+          <div class="bnf-top">
+           <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202203/1648185466264.png" alt="던킨"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">던킨</span>
+           <div class="badge-list">
+            <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+           </div>
+          </div>
+          <div class="bnf-info">
+           <dl class="dl-bnf">
+            <dt>
+             할인형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 할인
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 할인
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+           <dl class="dl-bnf">
+            <dt>
+             적립형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 적립
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 적립
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+          </div><span class="btn-round gra">자세히 보기</span> </a></li>
+       </ul>
+      </div>
+     </div><!-- //비슷한 혜택 브랜드 추천 영역 -->
+    </div>
+   </div><!--         <div id="footer"></div> -->
+   <div id="footer" class="main-footer">
+    <a href="#" class="footer__go-top"><span class="hidden">상단으로 이동</span></a>
+    <div class="main-footer__top">
+     <div class="footer_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="bar-list">
+       <div class="bar-list__item">
+        <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+       </div><!-- 2023-05-23 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+       </div><!-- 2023-05-23 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+       </div>
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+       </div>
+       <div class="bar-list__item">
+        <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+       </div>
+      </div>
+     </div>
+    </div>
+    <div class="main-footer__bottom">
+     <div class="footer_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="logo-list">
+       <div class="logo-list__item">
+        <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+          26년 연속 1위</span></a>
+       </div><!-- 2023-05-30 수정 -->
+       <div class="logo-list__item">
+        <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+          23년 연속 1위</span></a>
+       </div><!-- 20230508 수정 -->
+       <div class="logo-list__item">
+        <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+          25년 연속 1위</span></a>
+       </div><!-- 20230508 수정 -->
+       <div class="logo-list__item">
+        <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+       </div><!-- 20230508 수정 -->
+      </div>
+      <div class="footer__info-box width-auto">
+       <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+       <div class="column-box__item">
+        <div class="column-box__inner">
+         <div class="bar-list bar-list--narrow">
+          <div class="bar-list__item">
+           SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+           <br>
+           (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+          </div>
+          <hr class="bar-list--narrow bar-list--grey">
+          <div class="bar-list__item">
+           <strong>고객센터</strong>
+          </div>
+          <div class="bar-list__item">
+           대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+          </div><!-- 2023-05-23 수정 -->
+          <hr class="bar-list__line">
+          <div class="bar-list__item">
+           인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+          </div><!-- 2023-05-23 수정 -->
+          <div class="bar-list__item">
+           T 멤버십 마켓 : 1599-3377(유료)
+          </div><!-- 2023-05-23 수정 -->
+         </div>
+         <div class="bar-list bar-list--narrow bar-list--grey">
+          <div class="bar-list__item">
+           대표이사/사장 : 유영상
+          </div>
+          <div class="bar-list__item">
+           사업자등록번호 : 104-81-37225
+          </div>
+          <div class="bar-list__item">
+           판매허가번호 : 중구 02923호
+          </div>
+          <div class="bar-list__item">
+           <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+          </div>
+          <hr class="bar-list__line">
+          <div class="bar-list__item">
+           서울특별시 중구 을지로 65
+          </div>
+          <hr class="bar-list__line">
+          <div class="bar-list__item copyright">
+           COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+          </div>
+         </div>
+        </div>
+       </div>
+       <div class="column-box__item column-box__item--right">
+        <div class="column-box__inner">
+         <div class="site-list">
+          <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+          <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+           <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+           <div class="family-list" data-element="commonToggle__layer">
+            <div class="family-list__item">
+             <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+            </div><!-- 2023-05-30 수정 -->
+            <div class="family-list__item">
+             <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+            </div>
+            <div class="family-list__item">
+             <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+            </div>
+            <div class="family-list__item">
+             <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+            </div>
+           </div>
+          </div>
+         </div>
+         <div class="social-list">
+          <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+         </div>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+   <script type="text/javascript" src="/js/benefitbrand/MPW_D001_P03-f38ad4ae8f7e63be2335a3a34ed7a5af.js"></script>
+  </div>
+  <div class="toast01" data-toast="toastContainer" data-y="bottom" data-duration="800" data-pos="20" data-timer="3000">
+   <span id="toastContainer"></span>
+  </div>
+  <div class="loadingbar-area"></div>
+ </body>
+</html>
+<head>
+ <title>T 멤버십</title>
+ <meta charset="UTF-8">
+ <meta http-equiv="Content-Type" content="text/html">
+ <meta http-equiv="Content-Script-Type" content="text/javascript">
+ <meta http-equiv="Content-Style-Type" content="text/css">
+ <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, viewport-fit=cover">
+ <meta http-equiv="X-UA-compatible" content="IE=edge,chrome=1">
+ <link rel="shortcut icon" href="https://cdn.sktmembership.co.kr/mps.pc/favicon.ico" type="image/x-icon">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/poc/inc/css/footer.css">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/jquery-ui.min.css">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/swiper.min.css">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/common.css">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/style.css">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/wait.css">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/benefit.css">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/re_gnb.css">
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-3.4.1.min.js"></script>
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-ui.min.js"></script>
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/swiper.min.js"></script>
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/common.js"></script>
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/promise-polyfill.min.js"></script>
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/common/jsrender.js"></script>
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/axios.min.js"></script>
+ <script>
+        var CDN_PATH = "https:\/\/cdn.sktmembership.co.kr\/mps.pc";
+        var ENV = "prd";
+        var IS_LOGIN = false;
+        var IS_MBR_CARD = false;
+    </script>
+ <script type="text/javascript" src="/js/common-4c70bc9059822c175d8f8e59ac010eef.js"></script>
+ <script type="text/javascript" src="/js/netfunnel-194808761f66576464c07f70ba55a195.js"></script><!--     <link rel="stylesheet" type="text/css" th:href="@{${_config.url('/poc/gnb/inc/css/gnb.css')}}"> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/js/jquery.gnb.js')}}"></script> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/js/gnb.js')}}"></script> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/cmn/gnb_cmn.js')}}"></script> --> <!-- 	<script type="text/javascript" th:src="@{'/poc/gnb/inc/cmn/re_gnb.js'}"></script> -->
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/js/re_gnb.js"></script>
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/cmn/common_url_new.js"></script>
+ <script src="https://xtr.tos.sktelecom.com/js/xtractor_script.js"></script>
+</head>
+<title>T 멤버십</title>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Type" content="text/html">
+<meta http-equiv="Content-Script-Type" content="text/javascript">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, viewport-fit=cover">
+<meta http-equiv="X-UA-compatible" content="IE=edge,chrome=1">
+<link rel="shortcut icon" href="https://cdn.sktmembership.co.kr/mps.pc/favicon.ico" type="image/x-icon">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/poc/inc/css/footer.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/jquery-ui.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/swiper.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/common.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/style.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/wait.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/benefit.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/re_gnb.css">
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-3.4.1.min.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-ui.min.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/swiper.min.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/common.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/promise-polyfill.min.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/common/jsrender.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/axios.min.js"></script>
+<script>
+        var CDN_PATH = "https:\/\/cdn.sktmembership.co.kr\/mps.pc";
+        var ENV = "prd";
+        var IS_LOGIN = false;
+        var IS_MBR_CARD = false;
+    </script>
+<script type="text/javascript" src="/js/common-4c70bc9059822c175d8f8e59ac010eef.js"></script>
+<script type="text/javascript" src="/js/netfunnel-194808761f66576464c07f70ba55a195.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/js/re_gnb.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/cmn/common_url_new.js"></script>
+<script src="https://xtr.tos.sktelecom.com/js/xtractor_script.js"></script>
+<body>
+ <div class="accessbility">
+  <a href="#content">본문 바로가기</a>
+ </div>
+ <div class="wrap" id="wrap">
+  <!--<div id="header"></div>-->
+  <div id="header" class="main-header">
+   <input id="envUrl" hidden value="https://www.tworld.co.kr">
+   <div class="main-header__inner">
+    <!-- header 상단 기본 -->
+    <div class="main-header__top">
+     <div class="navi_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="main-header__logo">
+       <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+      </div>
+      <div class="main-header__util-item" id="gnb_login">
+       <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+       <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+      </div>
+      <div class="main-header__family-site family-list">
+       <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+      </div>
+     </div>
+    </div><!-- // header 상단 기본 --> <!-- GNB 기본 -->
+    <div class="main-header__bottom">
+     <div class="navi_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="main-header__menu gnb">
+       <!-- 활성화된 메뉴의 a 태그에 is-active -->
+       <div class="gnb__item">
+        <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+       </div>
+       <div class="gnb__item">
+        <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+       </div>
+       <div class="gnb__item">
+        <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+       </div>
+       <div class="gnb__item">
+        <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+       </div>
+       <div class="gnb__item">
+        <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+       </div>
+      </div>
+      <div class="main-header__util header-util">
+       <div class="header-util__item">
+        <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+       </div>
+      </div>
+     </div>
+    </div><!-- // GNB 기본 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T membership main --> <!-- 혜택 브랜드 --> <!-- 20230414 2depth 삭제 --> <!-- GNB 서브페이지 (상품서비스) -->
+    <div class="main-header__lnb" style="display: none;">
+     <div class="navi_cont">
+      <div class="main-header__menu header-lnb">
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+       </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+      </div>
+     </div>
+    </div><!-- // GNB 서브페이지 (my) --> <!-- //20230414 2depth 삭제 --> <!-- //혜택 브랜드 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 혜택 프로그램 --> <!-- GNB Family menu -->
+    <div class="main-header__lnb" style="display: none;">
+     <div class="navi_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="main-header__menu header-lnb">
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+       </div>
+      </div>
+     </div>
+    </div><!-- // GNB Family menu --> <!-- //혜택 프로그램 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 나의 T 멤버십 --> <!-- GNB Family menu -->
+    <div class="main-header__lnb" style="display: none;">
+     <div class="navi_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="main-header__menu header-lnb">
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+       </div>
+      </div>
+     </div>
+    </div><!-- // GNB Family menu --> <!-- //나의 T 멤버십 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T 멤버십 안내 --> <!-- GNB Family menu -->
+    <div class="main-header__lnb" style="display: none;">
+     <div class="navi_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="main-header__menu header-lnb">
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+       </div>
+      </div>
+     </div>
+    </div><!-- // GNB Family menu --> <!-- //T 멤버십 안내 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> -->
+   </div>
+  </div>
+  <div class="container">
+   <div id="content">
+    <div class="inr-wrap">
+     <div class="title-area">
+      <h1>배스킨라빈스</h1><input type="hidden" name="brandId" id="brandId" value="998"> <input type="hidden" name="brandName" id="brandName" value="배스킨라빈스">
+     </div><!-- 브랜드 상단 영역 -->
+     <div class="brnad-info-top">
+      <div class="bit-left">
+       <p class="tit">행복을 전하는 프리미엄 아이스크림, 배스킨라빈스</p>
+       <div class="badge-list">
+        <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+       </div>
+      </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202204/1649135025498.png" alt="배스킨라빈스"> </span>
+     </div><!-- //브랜드 상단 영역 --> <!-- 브랜드 선택 영역 -->
+     <div class="brand-sel-box">
+      <div class="fc-select">
+       <span>고객님이 선택하신 브랜드는</span>
+       <div class="dropdown" data-selectbox>
+        <a href="javascript:;" data-set-button> <span></span></a>
+        <div data-set-list>
+         <ul id="sel-ul">
+          <!-- 선택된 값에 'data-selected' 추가 -->
+          <li id="53"><a>베이커리</a></li>
+          <li id="54"><a>외식</a></li>
+          <li id="55" data-selected="data-selected"><a>카페/아이스크림</a></li>
+          <li id="56"><a>피자/치킨</a></li>
+          <li id="48"><a>금융/통신</a></li>
+          <li id="112"><a>렌탈</a></li>
+          <li id="116"><a>반려동물</a></li>
+          <li id="49"><a>생활/교통</a></li>
+          <li id="50"><a>쇼핑몰</a></li>
+          <li id="51"><a>패션/뷰티</a></li>
+          <li id="52"><a>편의점</a></li>
+          <li id="57"><a>교육</a></li>
+          <li id="109"><a>액티비티</a></li>
+          <li id="59"><a>여행</a></li>
+          <li id="60"><a>영화/공연/전시</a></li>
+          <li id="61"><a>콘텐츠</a></li>
+          <li id="110"><a>테마파크</a></li>
+         </ul>
+        </div>
+       </div>
+       <div class="dropdown" data-selectbox>
+        <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+        <div id="smallList" data-set-list>
+         <ul id="sel-list">
+          <li id="998" data-selected="data-selected"><a>배스킨라빈스</a></li>
+          <li id="771"><a>공차</a></li>
+          <li id="67"><a>폴 바셋</a></li>
+          <li id="992"><a>던킨</a></li>
+          <li id="887"><a>엔제리너스</a></li>
+          <li id="5051"><a>드롭탑</a></li>
+          <li id="961"><a>나뚜루&amp;나뚜루시그니처 </a></li>
+          <li id="1093"><a>미스터힐링</a></li>
+         </ul>
+        </div>
+       </div><span>입니다.</span>
+      </div>
+     </div><!-- //브랜드 선택 영역 --> <!-- 브랜드 상세 혜택 소개 영역 -->
+     <div class="brand-detail">
+      <div class="bd-top">
+       <div class="cate">
+        <span>EAT </span> <span>카페/아이스크림</span> <input type="hidden" name="categoryMid" id="categoryMid" value="55"> <input type="hidden" name="categoryMname" id="categoryMname" value="카페/아이스크림">
+       </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">149819</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="149819"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+      </div>
+      <div class="detail-list">
+       <dl>
+        <dt>
+         혜택
+        </dt>
+        <dd>
+         <dl class="dl-bnf">
+          <dt>
+           할인형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 할인(2,000원)
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 할인(1,200원)
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+           </div>
+          </dd>
+         </dl>
+         <dl class="dl-bnf">
+          <dt>
+           적립형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 적립(2,000P)
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 적립(1,200P)
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+           </div>
+          </dd>
+         </dl>
+        </dd>
+       </dl>
+       <dl>
+        <dt>
+         유의사항
+        </dt>
+        <dd>
+         <div class="notice">
+          <div class="explain-area pd-no">
+           <ul class="list-dot">
+            <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+            <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+            <li>대상 상품: 싱글레귤러(콘/컵 및 맛 선택 가능, 포장 안 됨)</li>
+            <li>횟수 제한 <br>
+             -할인: 월 1회, 싱글레귤러 1개 <br>
+             -적립: 월 1회, 싱글레귤러 1개 <br>
+             -포인트 사용: T 플러스포인트는 보유하신 한도 내에서 싱글레귤러 주문 시 횟수/수량 제한 없이 사용 가능</li>
+            <li>최대 할인 가능: VIP 2,000원, GOLD/SILVER 1,200원 할인</li>
+            <li>최대 적립 가능: VIP 2,000P, GOLD/SILVER 1,200P 적립</li>
+            <li>다른 행사 및 쿠폰, 제휴 할인과 중복 적용되지 않음</li>
+            <li>할인/적립/사용 금액 제외한 결제 금액의 0.1% 해피포인트 적립</li>
+            <li>모바일 교환권 사용 가능(단, 할인된 모바일 교환권은 사용할 수 없음)</li>
+            <li>매장에 방문하여 현장 구매 시 이용 가능(모바일 주문 및 배달 시 이용할 수 없음)</li>
+            <li>일부 매장 제외 (방문 전 매장 문의 및 배스킨라빈스 홈페이지 참조)</li>
+            <li>적립된 T 플러스포인트는 ‘적립 예정’ 포인트로 표시되며, 결제한 다음 날부터 사용 가능 포인트로 전환</li>
+            <li class="web-link"><a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a></li>
+            <li class="app-link"><a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a></li>
+           </ul>
+          </div>
+         </div>
+        </dd>
+       </dl>
+       <dl>
+        <dt>
+         문의 및 상담
+        </dt>
+        <dd>
+         <ul class="list-dash">
+          <li>TEL : 080-555-3131</li>
+          <li>HOME : <a href="javascript:goHomePage('')"></a></li>
+         </ul>
+        </dd>
+       </dl>
+      </div>
+     </div>
+    </div><!-- //브랜드 상세 혜택 소개 영역 --> <!-- 비슷한 혜택 브랜드 추천 영역 -->
+    <div class="similar-area">
+     <div class="inr-wrap">
+      <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+      <ul class="benefit-list">
+       <li><a href="javascript:;" class="benefit-box" id="67" data-title="폴 바셋" data-idx="0" data-cate-id="55" data-cate-name="카페/아이스크림">
+         <div class="bnf-top">
+          <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202211/1667888724269.png" alt="폴 바셋"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">폴 바셋</span>
+          <div class="badge-list">
+           <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+          </div>
+         </div>
+         <div class="bnf-info">
+          <dl class="dl-bnf">
+           <dt>
+            할인형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종(사이즈 무관) 구매 시 10% 할인
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+          <dl class="dl-bnf">
+           <dt>
+            적립형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피(사이즈 무관) 구매 시 10% 적립
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+         </div><span class="btn-round gra">자세히 보기</span> </a></li>
+       <li><a href="javascript:;" class="benefit-box" id="1093" data-title="미스터힐링" data-idx="1" data-cate-id="55" data-cate-name="카페/아이스크림">
+         <div class="bnf-top">
+          <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635300553816.png" alt="미스터힐링"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">미스터힐링</span>
+          <div class="badge-list">
+           <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+          </div>
+         </div>
+         <div class="bnf-info">
+          <dl class="dl-bnf">
+           <dt>
+            할인형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 할인
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+          <dl class="dl-bnf">
+           <dt>
+            적립형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 적립
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+         </div><span class="btn-round gra">자세히 보기</span> </a></li>
+       <li><a href="javascript:;" class="benefit-box" id="992" data-title="던킨" data-idx="2" data-cate-id="55" data-cate-name="카페/아이스크림">
+         <div class="bnf-top">
+          <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202203/1648185466264.png" alt="던킨"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">던킨</span>
+          <div class="badge-list">
+           <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+          </div>
+         </div>
+         <div class="bnf-info">
+          <dl class="dl-bnf">
+           <dt>
+            할인형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 할인
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 할인
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+          <dl class="dl-bnf">
+           <dt>
+            적립형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 적립
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 적립
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+         </div><span class="btn-round gra">자세히 보기</span> </a></li>
+      </ul>
+     </div>
+    </div><!-- //비슷한 혜택 브랜드 추천 영역 -->
+   </div>
+  </div><!--         <div id="footer"></div> -->
+  <div id="footer" class="main-footer">
+   <a href="#" class="footer__go-top"><span class="hidden">상단으로 이동</span></a>
+   <div class="main-footer__top">
+    <div class="footer_cont">
+     <!-- 20230411 클래스명 변경 -->
+     <div class="bar-list">
+      <div class="bar-list__item">
+       <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+      </div><!-- 2023-05-23 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+      </div><!-- 2023-05-23 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+      </div><!-- 230515 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+      </div><!-- 230515 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+      </div><!-- 230515 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+      </div><!-- 230515 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+      </div><!-- 230515 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+      </div>
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+      </div><!-- 230515 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+      </div><!-- 230515 수정 -->
+      <div class="bar-list__item">
+       <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+      </div>
+      <div class="bar-list__item">
+       <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+      </div>
+     </div>
+    </div>
+   </div>
+   <div class="main-footer__bottom">
+    <div class="footer_cont">
+     <!-- 20230411 클래스명 변경 -->
+     <div class="logo-list">
+      <div class="logo-list__item">
+       <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+         26년 연속 1위</span></a>
+      </div><!-- 2023-05-30 수정 -->
+      <div class="logo-list__item">
+       <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+         23년 연속 1위</span></a>
+      </div><!-- 20230508 수정 -->
+      <div class="logo-list__item">
+       <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+         25년 연속 1위</span></a>
+      </div><!-- 20230508 수정 -->
+      <div class="logo-list__item">
+       <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+      </div><!-- 20230508 수정 -->
+     </div>
+     <div class="footer__info-box width-auto">
+      <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+      <div class="column-box__item">
+       <div class="column-box__inner">
+        <div class="bar-list bar-list--narrow">
+         <div class="bar-list__item">
+          SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+          <br>
+          (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+         </div>
+         <hr class="bar-list--narrow bar-list--grey">
+         <div class="bar-list__item">
+          <strong>고객센터</strong>
+         </div>
+         <div class="bar-list__item">
+          대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+         </div><!-- 2023-05-23 수정 -->
+         <hr class="bar-list__line">
+         <div class="bar-list__item">
+          인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+         </div><!-- 2023-05-23 수정 -->
+         <div class="bar-list__item">
+          T 멤버십 마켓 : 1599-3377(유료)
+         </div><!-- 2023-05-23 수정 -->
+        </div>
+        <div class="bar-list bar-list--narrow bar-list--grey">
+         <div class="bar-list__item">
+          대표이사/사장 : 유영상
+         </div>
+         <div class="bar-list__item">
+          사업자등록번호 : 104-81-37225
+         </div>
+         <div class="bar-list__item">
+          판매허가번호 : 중구 02923호
+         </div>
+         <div class="bar-list__item">
+          <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+         </div>
+         <hr class="bar-list__line">
+         <div class="bar-list__item">
+          서울특별시 중구 을지로 65
+         </div>
+         <hr class="bar-list__line">
+         <div class="bar-list__item copyright">
+          COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+         </div>
+        </div>
+       </div>
+      </div>
+      <div class="column-box__item column-box__item--right">
+       <div class="column-box__inner">
+        <div class="site-list">
+         <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+         <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+          <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+          <div class="family-list" data-element="commonToggle__layer">
+           <div class="family-list__item">
+            <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+           </div><!-- 2023-05-30 수정 -->
+           <div class="family-list__item">
+            <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+           </div>
+           <div class="family-list__item">
+            <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+           </div>
+           <div class="family-list__item">
+            <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+           </div>
+           <div class="family-list__item">
+            <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+           </div>
+           <div class="family-list__item">
+            <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+           </div>
+           <div class="family-list__item">
+            <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+           </div>
+           <div class="family-list__item">
+            <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+           </div>
+           <div class="family-list__item">
+            <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+           </div>
+          </div>
+         </div>
+        </div>
+        <div class="social-list">
+         <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+  <script type="text/javascript" src="/js/benefitbrand/MPW_D001_P03-f38ad4ae8f7e63be2335a3a34ed7a5af.js"></script>
+ </div>
+ <div class="toast01" data-toast="toastContainer" data-y="bottom" data-duration="800" data-pos="20" data-timer="3000">
+  <span id="toastContainer"></span>
+ </div>
+ <div class="loadingbar-area"></div>
+</body>
+<div class="accessbility">
+ <a href="#content">본문 바로가기</a>
+</div>
+<a href="#content">본문 바로가기</a>
+<div class="wrap" id="wrap">
+ <!--<div id="header"></div>-->
+ <div id="header" class="main-header">
+  <input id="envUrl" hidden value="https://www.tworld.co.kr">
+  <div class="main-header__inner">
+   <!-- header 상단 기본 -->
+   <div class="main-header__top">
+    <div class="navi_cont">
+     <!-- 20230411 클래스명 변경 -->
+     <div class="main-header__logo">
+      <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+     </div>
+     <div class="main-header__util-item" id="gnb_login">
+      <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+      <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+     </div>
+     <div class="main-header__family-site family-list">
+      <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+     </div>
+    </div>
+   </div><!-- // header 상단 기본 --> <!-- GNB 기본 -->
+   <div class="main-header__bottom">
+    <div class="navi_cont">
+     <!-- 20230411 클래스명 변경 -->
+     <div class="main-header__menu gnb">
+      <!-- 활성화된 메뉴의 a 태그에 is-active -->
+      <div class="gnb__item">
+       <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+      </div>
+      <div class="gnb__item">
+       <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+      </div>
+      <div class="gnb__item">
+       <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+      </div>
+      <div class="gnb__item">
+       <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+      </div>
+      <div class="gnb__item">
+       <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+      </div>
+     </div>
+     <div class="main-header__util header-util">
+      <div class="header-util__item">
+       <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+      </div>
+     </div>
+    </div>
+   </div><!-- // GNB 기본 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T membership main --> <!-- 혜택 브랜드 --> <!-- 20230414 2depth 삭제 --> <!-- GNB 서브페이지 (상품서비스) -->
+   <div class="main-header__lnb" style="display: none;">
+    <div class="navi_cont">
+     <div class="main-header__menu header-lnb">
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+      </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+     </div>
+    </div>
+   </div><!-- // GNB 서브페이지 (my) --> <!-- //20230414 2depth 삭제 --> <!-- //혜택 브랜드 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 혜택 프로그램 --> <!-- GNB Family menu -->
+   <div class="main-header__lnb" style="display: none;">
+    <div class="navi_cont">
+     <!-- 20230411 클래스명 변경 -->
+     <div class="main-header__menu header-lnb">
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+      </div>
+     </div>
+    </div>
+   </div><!-- // GNB Family menu --> <!-- //혜택 프로그램 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 나의 T 멤버십 --> <!-- GNB Family menu -->
+   <div class="main-header__lnb" style="display: none;">
+    <div class="navi_cont">
+     <!-- 20230411 클래스명 변경 -->
+     <div class="main-header__menu header-lnb">
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+      </div>
+     </div>
+    </div>
+   </div><!-- // GNB Family menu --> <!-- //나의 T 멤버십 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T 멤버십 안내 --> <!-- GNB Family menu -->
+   <div class="main-header__lnb" style="display: none;">
+    <div class="navi_cont">
+     <!-- 20230411 클래스명 변경 -->
+     <div class="main-header__menu header-lnb">
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+      </div>
+     </div>
+    </div>
+   </div><!-- // GNB Family menu --> <!-- //T 멤버십 안내 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> -->
+  </div>
+ </div>
+ <div class="container">
+  <div id="content">
+   <div class="inr-wrap">
+    <div class="title-area">
+     <h1>배스킨라빈스</h1><input type="hidden" name="brandId" id="brandId" value="998"> <input type="hidden" name="brandName" id="brandName" value="배스킨라빈스">
+    </div><!-- 브랜드 상단 영역 -->
+    <div class="brnad-info-top">
+     <div class="bit-left">
+      <p class="tit">행복을 전하는 프리미엄 아이스크림, 배스킨라빈스</p>
+      <div class="badge-list">
+       <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+      </div>
+     </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202204/1649135025498.png" alt="배스킨라빈스"> </span>
+    </div><!-- //브랜드 상단 영역 --> <!-- 브랜드 선택 영역 -->
+    <div class="brand-sel-box">
+     <div class="fc-select">
+      <span>고객님이 선택하신 브랜드는</span>
+      <div class="dropdown" data-selectbox>
+       <a href="javascript:;" data-set-button> <span></span></a>
+       <div data-set-list>
+        <ul id="sel-ul">
+         <!-- 선택된 값에 'data-selected' 추가 -->
+         <li id="53"><a>베이커리</a></li>
+         <li id="54"><a>외식</a></li>
+         <li id="55" data-selected="data-selected"><a>카페/아이스크림</a></li>
+         <li id="56"><a>피자/치킨</a></li>
+         <li id="48"><a>금융/통신</a></li>
+         <li id="112"><a>렌탈</a></li>
+         <li id="116"><a>반려동물</a></li>
+         <li id="49"><a>생활/교통</a></li>
+         <li id="50"><a>쇼핑몰</a></li>
+         <li id="51"><a>패션/뷰티</a></li>
+         <li id="52"><a>편의점</a></li>
+         <li id="57"><a>교육</a></li>
+         <li id="109"><a>액티비티</a></li>
+         <li id="59"><a>여행</a></li>
+         <li id="60"><a>영화/공연/전시</a></li>
+         <li id="61"><a>콘텐츠</a></li>
+         <li id="110"><a>테마파크</a></li>
+        </ul>
+       </div>
+      </div>
+      <div class="dropdown" data-selectbox>
+       <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+       <div id="smallList" data-set-list>
+        <ul id="sel-list">
+         <li id="998" data-selected="data-selected"><a>배스킨라빈스</a></li>
+         <li id="771"><a>공차</a></li>
+         <li id="67"><a>폴 바셋</a></li>
+         <li id="992"><a>던킨</a></li>
+         <li id="887"><a>엔제리너스</a></li>
+         <li id="5051"><a>드롭탑</a></li>
+         <li id="961"><a>나뚜루&amp;나뚜루시그니처 </a></li>
+         <li id="1093"><a>미스터힐링</a></li>
+        </ul>
+       </div>
+      </div><span>입니다.</span>
+     </div>
+    </div><!-- //브랜드 선택 영역 --> <!-- 브랜드 상세 혜택 소개 영역 -->
+    <div class="brand-detail">
+     <div class="bd-top">
+      <div class="cate">
+       <span>EAT </span> <span>카페/아이스크림</span> <input type="hidden" name="categoryMid" id="categoryMid" value="55"> <input type="hidden" name="categoryMname" id="categoryMname" value="카페/아이스크림">
+      </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">149819</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="149819"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+     </div>
+     <div class="detail-list">
+      <dl>
+       <dt>
+        혜택
+       </dt>
+       <dd>
+        <dl class="dl-bnf">
+         <dt>
+          할인형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 할인(2,000원)
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 할인(1,200원)
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+          </div>
+         </dd>
+        </dl>
+        <dl class="dl-bnf">
+         <dt>
+          적립형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 적립(2,000P)
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 적립(1,200P)
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+          </div>
+         </dd>
+        </dl>
+       </dd>
+      </dl>
+      <dl>
+       <dt>
+        유의사항
+       </dt>
+       <dd>
+        <div class="notice">
+         <div class="explain-area pd-no">
+          <ul class="list-dot">
+           <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+           <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+           <li>대상 상품: 싱글레귤러(콘/컵 및 맛 선택 가능, 포장 안 됨)</li>
+           <li>횟수 제한 <br>
+            -할인: 월 1회, 싱글레귤러 1개 <br>
+            -적립: 월 1회, 싱글레귤러 1개 <br>
+            -포인트 사용: T 플러스포인트는 보유하신 한도 내에서 싱글레귤러 주문 시 횟수/수량 제한 없이 사용 가능</li>
+           <li>최대 할인 가능: VIP 2,000원, GOLD/SILVER 1,200원 할인</li>
+           <li>최대 적립 가능: VIP 2,000P, GOLD/SILVER 1,200P 적립</li>
+           <li>다른 행사 및 쿠폰, 제휴 할인과 중복 적용되지 않음</li>
+           <li>할인/적립/사용 금액 제외한 결제 금액의 0.1% 해피포인트 적립</li>
+           <li>모바일 교환권 사용 가능(단, 할인된 모바일 교환권은 사용할 수 없음)</li>
+           <li>매장에 방문하여 현장 구매 시 이용 가능(모바일 주문 및 배달 시 이용할 수 없음)</li>
+           <li>일부 매장 제외 (방문 전 매장 문의 및 배스킨라빈스 홈페이지 참조)</li>
+           <li>적립된 T 플러스포인트는 ‘적립 예정’ 포인트로 표시되며, 결제한 다음 날부터 사용 가능 포인트로 전환</li>
+           <li class="web-link"><a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a></li>
+           <li class="app-link"><a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a></li>
+          </ul>
+         </div>
+        </div>
+       </dd>
+      </dl>
+      <dl>
+       <dt>
+        문의 및 상담
+       </dt>
+       <dd>
+        <ul class="list-dash">
+         <li>TEL : 080-555-3131</li>
+         <li>HOME : <a href="javascript:goHomePage('')"></a></li>
+        </ul>
+       </dd>
+      </dl>
+     </div>
+    </div>
+   </div><!-- //브랜드 상세 혜택 소개 영역 --> <!-- 비슷한 혜택 브랜드 추천 영역 -->
+   <div class="similar-area">
+    <div class="inr-wrap">
+     <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+     <ul class="benefit-list">
+      <li><a href="javascript:;" class="benefit-box" id="67" data-title="폴 바셋" data-idx="0" data-cate-id="55" data-cate-name="카페/아이스크림">
+        <div class="bnf-top">
+         <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202211/1667888724269.png" alt="폴 바셋"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">폴 바셋</span>
+         <div class="badge-list">
+          <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+         </div>
+        </div>
+        <div class="bnf-info">
+         <dl class="dl-bnf">
+          <dt>
+           할인형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종(사이즈 무관) 구매 시 10% 할인
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+           </div>
+          </dd>
+         </dl>
+         <dl class="dl-bnf">
+          <dt>
+           적립형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피(사이즈 무관) 구매 시 10% 적립
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+           </div>
+          </dd>
+         </dl>
+        </div><span class="btn-round gra">자세히 보기</span> </a></li>
+      <li><a href="javascript:;" class="benefit-box" id="1093" data-title="미스터힐링" data-idx="1" data-cate-id="55" data-cate-name="카페/아이스크림">
+        <div class="bnf-top">
+         <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635300553816.png" alt="미스터힐링"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">미스터힐링</span>
+         <div class="badge-list">
+          <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+         </div>
+        </div>
+        <div class="bnf-info">
+         <dl class="dl-bnf">
+          <dt>
+           할인형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 할인
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+           </div>
+          </dd>
+         </dl>
+         <dl class="dl-bnf">
+          <dt>
+           적립형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 적립
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+           </div>
+          </dd>
+         </dl>
+        </div><span class="btn-round gra">자세히 보기</span> </a></li>
+      <li><a href="javascript:;" class="benefit-box" id="992" data-title="던킨" data-idx="2" data-cate-id="55" data-cate-name="카페/아이스크림">
+        <div class="bnf-top">
+         <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202203/1648185466264.png" alt="던킨"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">던킨</span>
+         <div class="badge-list">
+          <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+         </div>
+        </div>
+        <div class="bnf-info">
+         <dl class="dl-bnf">
+          <dt>
+           할인형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 할인
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 할인
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+           </div>
+          </dd>
+         </dl>
+         <dl class="dl-bnf">
+          <dt>
+           적립형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 적립
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 적립
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+           </div>
+          </dd>
+         </dl>
+        </div><span class="btn-round gra">자세히 보기</span> </a></li>
+     </ul>
+    </div>
+   </div><!-- //비슷한 혜택 브랜드 추천 영역 -->
+  </div>
+ </div><!--         <div id="footer"></div> -->
+ <div id="footer" class="main-footer">
+  <a href="#" class="footer__go-top"><span class="hidden">상단으로 이동</span></a>
+  <div class="main-footer__top">
+   <div class="footer_cont">
+    <!-- 20230411 클래스명 변경 -->
+    <div class="bar-list">
+     <div class="bar-list__item">
+      <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+     </div><!-- 2023-05-23 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+     </div><!-- 2023-05-23 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+     </div><!-- 230515 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+     </div><!-- 230515 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+     </div><!-- 230515 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+     </div><!-- 230515 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+     </div><!-- 230515 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+     </div>
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+     </div><!-- 230515 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+     </div><!-- 230515 수정 -->
+     <div class="bar-list__item">
+      <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+     </div>
+     <div class="bar-list__item">
+      <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+     </div>
+    </div>
+   </div>
+  </div>
+  <div class="main-footer__bottom">
+   <div class="footer_cont">
+    <!-- 20230411 클래스명 변경 -->
+    <div class="logo-list">
+     <div class="logo-list__item">
+      <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+        26년 연속 1위</span></a>
+     </div><!-- 2023-05-30 수정 -->
+     <div class="logo-list__item">
+      <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+        23년 연속 1위</span></a>
+     </div><!-- 20230508 수정 -->
+     <div class="logo-list__item">
+      <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+        25년 연속 1위</span></a>
+     </div><!-- 20230508 수정 -->
+     <div class="logo-list__item">
+      <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+     </div><!-- 20230508 수정 -->
+    </div>
+    <div class="footer__info-box width-auto">
+     <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+     <div class="column-box__item">
+      <div class="column-box__inner">
+       <div class="bar-list bar-list--narrow">
+        <div class="bar-list__item">
+         SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+         <br>
+         (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+        </div>
+        <hr class="bar-list--narrow bar-list--grey">
+        <div class="bar-list__item">
+         <strong>고객센터</strong>
+        </div>
+        <div class="bar-list__item">
+         대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+        </div><!-- 2023-05-23 수정 -->
+        <hr class="bar-list__line">
+        <div class="bar-list__item">
+         인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+        </div><!-- 2023-05-23 수정 -->
+        <div class="bar-list__item">
+         T 멤버십 마켓 : 1599-3377(유료)
+        </div><!-- 2023-05-23 수정 -->
+       </div>
+       <div class="bar-list bar-list--narrow bar-list--grey">
+        <div class="bar-list__item">
+         대표이사/사장 : 유영상
+        </div>
+        <div class="bar-list__item">
+         사업자등록번호 : 104-81-37225
+        </div>
+        <div class="bar-list__item">
+         판매허가번호 : 중구 02923호
+        </div>
+        <div class="bar-list__item">
+         <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+        </div>
+        <hr class="bar-list__line">
+        <div class="bar-list__item">
+         서울특별시 중구 을지로 65
+        </div>
+        <hr class="bar-list__line">
+        <div class="bar-list__item copyright">
+         COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+        </div>
+       </div>
+      </div>
+     </div>
+     <div class="column-box__item column-box__item--right">
+      <div class="column-box__inner">
+       <div class="site-list">
+        <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+        <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+         <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+         <div class="family-list" data-element="commonToggle__layer">
+          <div class="family-list__item">
+           <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+          </div><!-- 2023-05-30 수정 -->
+          <div class="family-list__item">
+           <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+          </div>
+          <div class="family-list__item">
+           <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+          </div>
+          <div class="family-list__item">
+           <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+          </div>
+          <div class="family-list__item">
+           <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+          </div>
+          <div class="family-list__item">
+           <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+          </div>
+          <div class="family-list__item">
+           <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+          </div>
+          <div class="family-list__item">
+           <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+          </div>
+          <div class="family-list__item">
+           <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+          </div>
+         </div>
+        </div>
+       </div>
+       <div class="social-list">
+        <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+ </div>
+ <script type="text/javascript" src="/js/benefitbrand/MPW_D001_P03-f38ad4ae8f7e63be2335a3a34ed7a5af.js"></script>
+</div>
+<div id="header" class="main-header">
+ <input id="envUrl" hidden value="https://www.tworld.co.kr">
+ <div class="main-header__inner">
+  <!-- header 상단 기본 -->
+  <div class="main-header__top">
+   <div class="navi_cont">
+    <!-- 20230411 클래스명 변경 -->
+    <div class="main-header__logo">
+     <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+    </div>
+    <div class="main-header__util-item" id="gnb_login">
+     <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+     <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+    </div>
+    <div class="main-header__family-site family-list">
+     <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+    </div>
+   </div>
+  </div><!-- // header 상단 기본 --> <!-- GNB 기본 -->
+  <div class="main-header__bottom">
+   <div class="navi_cont">
+    <!-- 20230411 클래스명 변경 -->
+    <div class="main-header__menu gnb">
+     <!-- 활성화된 메뉴의 a 태그에 is-active -->
+     <div class="gnb__item">
+      <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+     </div>
+     <div class="gnb__item">
+      <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+     </div>
+     <div class="gnb__item">
+      <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+     </div>
+     <div class="gnb__item">
+      <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+     </div>
+     <div class="gnb__item">
+      <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+     </div>
+    </div>
+    <div class="main-header__util header-util">
+     <div class="header-util__item">
+      <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+     </div>
+    </div>
+   </div>
+  </div><!-- // GNB 기본 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T membership main --> <!-- 혜택 브랜드 --> <!-- 20230414 2depth 삭제 --> <!-- GNB 서브페이지 (상품서비스) -->
+  <div class="main-header__lnb" style="display: none;">
+   <div class="navi_cont">
+    <div class="main-header__menu header-lnb">
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+     </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+    </div>
+   </div>
+  </div><!-- // GNB 서브페이지 (my) --> <!-- //20230414 2depth 삭제 --> <!-- //혜택 브랜드 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 혜택 프로그램 --> <!-- GNB Family menu -->
+  <div class="main-header__lnb" style="display: none;">
+   <div class="navi_cont">
+    <!-- 20230411 클래스명 변경 -->
+    <div class="main-header__menu header-lnb">
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+     </div>
+    </div>
+   </div>
+  </div><!-- // GNB Family menu --> <!-- //혜택 프로그램 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 나의 T 멤버십 --> <!-- GNB Family menu -->
+  <div class="main-header__lnb" style="display: none;">
+   <div class="navi_cont">
+    <!-- 20230411 클래스명 변경 -->
+    <div class="main-header__menu header-lnb">
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+     </div>
+    </div>
+   </div>
+  </div><!-- // GNB Family menu --> <!-- //나의 T 멤버십 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T 멤버십 안내 --> <!-- GNB Family menu -->
+  <div class="main-header__lnb" style="display: none;">
+   <div class="navi_cont">
+    <!-- 20230411 클래스명 변경 -->
+    <div class="main-header__menu header-lnb">
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+     </div>
+    </div>
+   </div>
+  </div><!-- // GNB Family menu --> <!-- //T 멤버십 안내 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> -->
+ </div>
+</div>
+<input id="envUrl" hidden value="https://www.tworld.co.kr">
+<div class="main-header__inner">
+ <!-- header 상단 기본 -->
+ <div class="main-header__top">
+  <div class="navi_cont">
+   <!-- 20230411 클래스명 변경 -->
+   <div class="main-header__logo">
+    <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+   </div>
+   <div class="main-header__util-item" id="gnb_login">
+    <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+    <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+   </div>
+   <div class="main-header__family-site family-list">
+    <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+   </div>
+  </div>
+ </div><!-- // header 상단 기본 --> <!-- GNB 기본 -->
+ <div class="main-header__bottom">
+  <div class="navi_cont">
+   <!-- 20230411 클래스명 변경 -->
+   <div class="main-header__menu gnb">
+    <!-- 활성화된 메뉴의 a 태그에 is-active -->
+    <div class="gnb__item">
+     <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+    </div>
+    <div class="gnb__item">
+     <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+    </div>
+    <div class="gnb__item">
+     <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+    </div>
+    <div class="gnb__item">
+     <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+    </div>
+    <div class="gnb__item">
+     <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+    </div>
+   </div>
+   <div class="main-header__util header-util">
+    <div class="header-util__item">
+     <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+    </div>
+   </div>
+  </div>
+ </div><!-- // GNB 기본 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T membership main --> <!-- 혜택 브랜드 --> <!-- 20230414 2depth 삭제 --> <!-- GNB 서브페이지 (상품서비스) -->
+ <div class="main-header__lnb" style="display: none;">
+  <div class="navi_cont">
+   <div class="main-header__menu header-lnb">
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+    </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+   </div>
+  </div>
+ </div><!-- // GNB 서브페이지 (my) --> <!-- //20230414 2depth 삭제 --> <!-- //혜택 브랜드 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 혜택 프로그램 --> <!-- GNB Family menu -->
+ <div class="main-header__lnb" style="display: none;">
+  <div class="navi_cont">
+   <!-- 20230411 클래스명 변경 -->
+   <div class="main-header__menu header-lnb">
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+    </div>
+   </div>
+  </div>
+ </div><!-- // GNB Family menu --> <!-- //혜택 프로그램 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 나의 T 멤버십 --> <!-- GNB Family menu -->
+ <div class="main-header__lnb" style="display: none;">
+  <div class="navi_cont">
+   <!-- 20230411 클래스명 변경 -->
+   <div class="main-header__menu header-lnb">
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+    </div>
+   </div>
+  </div>
+ </div><!-- // GNB Family menu --> <!-- //나의 T 멤버십 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T 멤버십 안내 --> <!-- GNB Family menu -->
+ <div class="main-header__lnb" style="display: none;">
+  <div class="navi_cont">
+   <!-- 20230411 클래스명 변경 -->
+   <div class="main-header__menu header-lnb">
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+    </div>
+   </div>
+  </div>
+ </div><!-- // GNB Family menu --> <!-- //T 멤버십 안내 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> -->
+</div>
+<div class="main-header__top">
+ <div class="navi_cont">
+  <!-- 20230411 클래스명 변경 -->
+  <div class="main-header__logo">
+   <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+  </div>
+  <div class="main-header__util-item" id="gnb_login">
+   <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+   <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+  </div>
+  <div class="main-header__family-site family-list">
+   <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+  </div>
+ </div>
+</div>
+<div class="navi_cont">
+ <!-- 20230411 클래스명 변경 -->
+ <div class="main-header__logo">
+  <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+ </div>
+ <div class="main-header__util-item" id="gnb_login">
+  <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+  <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+ </div>
+ <div class="main-header__family-site family-list">
+  <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+ </div>
+</div>
+<div class="main-header__logo">
+ <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+</div>
+<a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+<img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world">
+<div class="main-header__util-item" id="gnb_login">
+ <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+ <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+</div>
+<a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a>
+<span>T world 통합 검색</span>
+<a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a>
+<span>로그인</span>
+<a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a>
+<span>SK텔레콤 T 아이디 회원가입</span>
+<script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+<div class="main-header__family-site family-list">
+ <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+</div>
+<a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a>
+<span class="hidden">T 우주</span>
+<a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+<span class="hidden">T roaming</span>
+<div class="main-header__bottom">
+ <div class="navi_cont">
+  <!-- 20230411 클래스명 변경 -->
+  <div class="main-header__menu gnb">
+   <!-- 활성화된 메뉴의 a 태그에 is-active -->
+   <div class="gnb__item">
+    <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+   </div>
+   <div class="gnb__item">
+    <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+   </div>
+   <div class="gnb__item">
+    <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+   </div>
+   <div class="gnb__item">
+    <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+   </div>
+   <div class="gnb__item">
+    <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+   </div>
+  </div>
+  <div class="main-header__util header-util">
+   <div class="header-util__item">
+    <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="navi_cont">
+ <!-- 20230411 클래스명 변경 -->
+ <div class="main-header__menu gnb">
+  <!-- 활성화된 메뉴의 a 태그에 is-active -->
+  <div class="gnb__item">
+   <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+  </div>
+  <div class="gnb__item">
+   <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+  </div>
+  <div class="gnb__item">
+   <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+  </div>
+  <div class="gnb__item">
+   <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+  </div>
+  <div class="gnb__item">
+   <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+  </div>
+ </div>
+ <div class="main-header__util header-util">
+  <div class="header-util__item">
+   <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+  </div>
+ </div>
+</div>
+<div class="main-header__menu gnb">
+ <!-- 활성화된 메뉴의 a 태그에 is-active -->
+ <div class="gnb__item">
+  <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+ </div>
+ <div class="gnb__item">
+  <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+ </div>
+ <div class="gnb__item">
+  <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+ </div>
+ <div class="gnb__item">
+  <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+ </div>
+ <div class="gnb__item">
+  <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+ </div>
+</div>
+<div class="gnb__item">
+ <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+</div>
+<a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+<img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership">
+<div class="gnb__item">
+ <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+</div>
+<a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+<div class="gnb__item">
+ <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+</div>
+<a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+<div class="gnb__item">
+ <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+</div>
+<a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+<div class="gnb__item">
+ <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+</div>
+<a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+<div class="main-header__util header-util">
+ <div class="header-util__item">
+  <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+ </div>
+</div>
+<div class="header-util__item">
+ <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+</div>
+<a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+<button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button>
+<span class="hidden">전체메뉴</span>
+<div class="main-header__lnb" style="display: none;">
+ <div class="navi_cont">
+  <div class="main-header__menu header-lnb">
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+   </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+  </div>
+ </div>
+</div>
+<div class="navi_cont">
+ <div class="main-header__menu header-lnb">
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+  </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+ </div>
+</div>
+<div class="main-header__menu header-lnb">
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+ </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+</div>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+</div>
+<a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+<div class="main-header__lnb" style="display: none;">
+ <div class="navi_cont">
+  <!-- 20230411 클래스명 변경 -->
+  <div class="main-header__menu header-lnb">
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="navi_cont">
+ <!-- 20230411 클래스명 변경 -->
+ <div class="main-header__menu header-lnb">
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+  </div>
+ </div>
+</div>
+<div class="main-header__menu header-lnb">
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+ </div>
+</div>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+</div>
+<a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+</div>
+<a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+</div>
+<a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+</div>
+<a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+</div>
+<a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+</div>
+<a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+</div>
+<a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+<div class="main-header__lnb" style="display: none;">
+ <div class="navi_cont">
+  <!-- 20230411 클래스명 변경 -->
+  <div class="main-header__menu header-lnb">
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="navi_cont">
+ <!-- 20230411 클래스명 변경 -->
+ <div class="main-header__menu header-lnb">
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+  </div>
+ </div>
+</div>
+<div class="main-header__menu header-lnb">
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+ </div>
+</div>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+</div>
+<a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+</div>
+<a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+</div>
+<a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+</div>
+<a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+<div class="main-header__lnb" style="display: none;">
+ <div class="navi_cont">
+  <!-- 20230411 클래스명 변경 -->
+  <div class="main-header__menu header-lnb">
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="navi_cont">
+ <!-- 20230411 클래스명 변경 -->
+ <div class="main-header__menu header-lnb">
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+  </div>
+ </div>
+</div>
+<div class="main-header__menu header-lnb">
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+ </div>
+</div>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+</div>
+<a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+</div>
+<a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+<div class="header-lnb__item">
+ <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+</div>
+<a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+<div class="header-lnb__item">
+ <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+</div>
+<a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+<div class="container">
+ <div id="content">
+  <div class="inr-wrap">
+   <div class="title-area">
+    <h1>배스킨라빈스</h1><input type="hidden" name="brandId" id="brandId" value="998"> <input type="hidden" name="brandName" id="brandName" value="배스킨라빈스">
+   </div><!-- 브랜드 상단 영역 -->
+   <div class="brnad-info-top">
+    <div class="bit-left">
+     <p class="tit">행복을 전하는 프리미엄 아이스크림, 배스킨라빈스</p>
+     <div class="badge-list">
+      <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+     </div>
+    </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202204/1649135025498.png" alt="배스킨라빈스"> </span>
+   </div><!-- //브랜드 상단 영역 --> <!-- 브랜드 선택 영역 -->
+   <div class="brand-sel-box">
+    <div class="fc-select">
+     <span>고객님이 선택하신 브랜드는</span>
+     <div class="dropdown" data-selectbox>
+      <a href="javascript:;" data-set-button> <span></span></a>
+      <div data-set-list>
+       <ul id="sel-ul">
+        <!-- 선택된 값에 'data-selected' 추가 -->
+        <li id="53"><a>베이커리</a></li>
+        <li id="54"><a>외식</a></li>
+        <li id="55" data-selected="data-selected"><a>카페/아이스크림</a></li>
+        <li id="56"><a>피자/치킨</a></li>
+        <li id="48"><a>금융/통신</a></li>
+        <li id="112"><a>렌탈</a></li>
+        <li id="116"><a>반려동물</a></li>
+        <li id="49"><a>생활/교통</a></li>
+        <li id="50"><a>쇼핑몰</a></li>
+        <li id="51"><a>패션/뷰티</a></li>
+        <li id="52"><a>편의점</a></li>
+        <li id="57"><a>교육</a></li>
+        <li id="109"><a>액티비티</a></li>
+        <li id="59"><a>여행</a></li>
+        <li id="60"><a>영화/공연/전시</a></li>
+        <li id="61"><a>콘텐츠</a></li>
+        <li id="110"><a>테마파크</a></li>
+       </ul>
+      </div>
+     </div>
+     <div class="dropdown" data-selectbox>
+      <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+      <div id="smallList" data-set-list>
+       <ul id="sel-list">
+        <li id="998" data-selected="data-selected"><a>배스킨라빈스</a></li>
+        <li id="771"><a>공차</a></li>
+        <li id="67"><a>폴 바셋</a></li>
+        <li id="992"><a>던킨</a></li>
+        <li id="887"><a>엔제리너스</a></li>
+        <li id="5051"><a>드롭탑</a></li>
+        <li id="961"><a>나뚜루&amp;나뚜루시그니처 </a></li>
+        <li id="1093"><a>미스터힐링</a></li>
+       </ul>
+      </div>
+     </div><span>입니다.</span>
+    </div>
+   </div><!-- //브랜드 선택 영역 --> <!-- 브랜드 상세 혜택 소개 영역 -->
+   <div class="brand-detail">
+    <div class="bd-top">
+     <div class="cate">
+      <span>EAT </span> <span>카페/아이스크림</span> <input type="hidden" name="categoryMid" id="categoryMid" value="55"> <input type="hidden" name="categoryMname" id="categoryMname" value="카페/아이스크림">
+     </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">149819</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="149819"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+    </div>
+    <div class="detail-list">
+     <dl>
+      <dt>
+       혜택
+      </dt>
+      <dd>
+       <dl class="dl-bnf">
+        <dt>
+         할인형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 할인(2,000원)
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 할인(1,200원)
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+         </div>
+        </dd>
+       </dl>
+       <dl class="dl-bnf">
+        <dt>
+         적립형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 적립(2,000P)
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 적립(1,200P)
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+         </div>
+        </dd>
+       </dl>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       유의사항
+      </dt>
+      <dd>
+       <div class="notice">
+        <div class="explain-area pd-no">
+         <ul class="list-dot">
+          <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+          <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+          <li>대상 상품: 싱글레귤러(콘/컵 및 맛 선택 가능, 포장 안 됨)</li>
+          <li>횟수 제한 <br>
+           -할인: 월 1회, 싱글레귤러 1개 <br>
+           -적립: 월 1회, 싱글레귤러 1개 <br>
+           -포인트 사용: T 플러스포인트는 보유하신 한도 내에서 싱글레귤러 주문 시 횟수/수량 제한 없이 사용 가능</li>
+          <li>최대 할인 가능: VIP 2,000원, GOLD/SILVER 1,200원 할인</li>
+          <li>최대 적립 가능: VIP 2,000P, GOLD/SILVER 1,200P 적립</li>
+          <li>다른 행사 및 쿠폰, 제휴 할인과 중복 적용되지 않음</li>
+          <li>할인/적립/사용 금액 제외한 결제 금액의 0.1% 해피포인트 적립</li>
+          <li>모바일 교환권 사용 가능(단, 할인된 모바일 교환권은 사용할 수 없음)</li>
+          <li>매장에 방문하여 현장 구매 시 이용 가능(모바일 주문 및 배달 시 이용할 수 없음)</li>
+          <li>일부 매장 제외 (방문 전 매장 문의 및 배스킨라빈스 홈페이지 참조)</li>
+          <li>적립된 T 플러스포인트는 ‘적립 예정’ 포인트로 표시되며, 결제한 다음 날부터 사용 가능 포인트로 전환</li>
+          <li class="web-link"><a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a></li>
+          <li class="app-link"><a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a></li>
+         </ul>
+        </div>
+       </div>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       문의 및 상담
+      </dt>
+      <dd>
+       <ul class="list-dash">
+        <li>TEL : 080-555-3131</li>
+        <li>HOME : <a href="javascript:goHomePage('')"></a></li>
+       </ul>
+      </dd>
+     </dl>
+    </div>
+   </div>
+  </div><!-- //브랜드 상세 혜택 소개 영역 --> <!-- 비슷한 혜택 브랜드 추천 영역 -->
+  <div class="similar-area">
+   <div class="inr-wrap">
+    <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+    <ul class="benefit-list">
+     <li><a href="javascript:;" class="benefit-box" id="67" data-title="폴 바셋" data-idx="0" data-cate-id="55" data-cate-name="카페/아이스크림">
+       <div class="bnf-top">
+        <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202211/1667888724269.png" alt="폴 바셋"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">폴 바셋</span>
+        <div class="badge-list">
+         <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+        </div>
+       </div>
+       <div class="bnf-info">
+        <dl class="dl-bnf">
+         <dt>
+          할인형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종(사이즈 무관) 구매 시 10% 할인
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+          </div>
+         </dd>
+        </dl>
+        <dl class="dl-bnf">
+         <dt>
+          적립형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피(사이즈 무관) 구매 시 10% 적립
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+          </div>
+         </dd>
+        </dl>
+       </div><span class="btn-round gra">자세히 보기</span> </a></li>
+     <li><a href="javascript:;" class="benefit-box" id="1093" data-title="미스터힐링" data-idx="1" data-cate-id="55" data-cate-name="카페/아이스크림">
+       <div class="bnf-top">
+        <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635300553816.png" alt="미스터힐링"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">미스터힐링</span>
+        <div class="badge-list">
+         <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+        </div>
+       </div>
+       <div class="bnf-info">
+        <dl class="dl-bnf">
+         <dt>
+          할인형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 할인
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+          </div>
+         </dd>
+        </dl>
+        <dl class="dl-bnf">
+         <dt>
+          적립형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 적립
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+          </div>
+         </dd>
+        </dl>
+       </div><span class="btn-round gra">자세히 보기</span> </a></li>
+     <li><a href="javascript:;" class="benefit-box" id="992" data-title="던킨" data-idx="2" data-cate-id="55" data-cate-name="카페/아이스크림">
+       <div class="bnf-top">
+        <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202203/1648185466264.png" alt="던킨"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">던킨</span>
+        <div class="badge-list">
+         <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+        </div>
+       </div>
+       <div class="bnf-info">
+        <dl class="dl-bnf">
+         <dt>
+          할인형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 할인
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 할인
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+          </div>
+         </dd>
+        </dl>
+        <dl class="dl-bnf">
+         <dt>
+          적립형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 적립
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 적립
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+          </div>
+         </dd>
+        </dl>
+       </div><span class="btn-round gra">자세히 보기</span> </a></li>
+    </ul>
+   </div>
+  </div><!-- //비슷한 혜택 브랜드 추천 영역 -->
+ </div>
+</div>
+<div id="content">
+ <div class="inr-wrap">
+  <div class="title-area">
+   <h1>배스킨라빈스</h1><input type="hidden" name="brandId" id="brandId" value="998"> <input type="hidden" name="brandName" id="brandName" value="배스킨라빈스">
+  </div><!-- 브랜드 상단 영역 -->
+  <div class="brnad-info-top">
+   <div class="bit-left">
+    <p class="tit">행복을 전하는 프리미엄 아이스크림, 배스킨라빈스</p>
+    <div class="badge-list">
+     <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+    </div>
+   </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202204/1649135025498.png" alt="배스킨라빈스"> </span>
+  </div><!-- //브랜드 상단 영역 --> <!-- 브랜드 선택 영역 -->
+  <div class="brand-sel-box">
+   <div class="fc-select">
+    <span>고객님이 선택하신 브랜드는</span>
+    <div class="dropdown" data-selectbox>
+     <a href="javascript:;" data-set-button> <span></span></a>
+     <div data-set-list>
+      <ul id="sel-ul">
+       <!-- 선택된 값에 'data-selected' 추가 -->
+       <li id="53"><a>베이커리</a></li>
+       <li id="54"><a>외식</a></li>
+       <li id="55" data-selected="data-selected"><a>카페/아이스크림</a></li>
+       <li id="56"><a>피자/치킨</a></li>
+       <li id="48"><a>금융/통신</a></li>
+       <li id="112"><a>렌탈</a></li>
+       <li id="116"><a>반려동물</a></li>
+       <li id="49"><a>생활/교통</a></li>
+       <li id="50"><a>쇼핑몰</a></li>
+       <li id="51"><a>패션/뷰티</a></li>
+       <li id="52"><a>편의점</a></li>
+       <li id="57"><a>교육</a></li>
+       <li id="109"><a>액티비티</a></li>
+       <li id="59"><a>여행</a></li>
+       <li id="60"><a>영화/공연/전시</a></li>
+       <li id="61"><a>콘텐츠</a></li>
+       <li id="110"><a>테마파크</a></li>
+      </ul>
+     </div>
+    </div>
+    <div class="dropdown" data-selectbox>
+     <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+     <div id="smallList" data-set-list>
+      <ul id="sel-list">
+       <li id="998" data-selected="data-selected"><a>배스킨라빈스</a></li>
+       <li id="771"><a>공차</a></li>
+       <li id="67"><a>폴 바셋</a></li>
+       <li id="992"><a>던킨</a></li>
+       <li id="887"><a>엔제리너스</a></li>
+       <li id="5051"><a>드롭탑</a></li>
+       <li id="961"><a>나뚜루&amp;나뚜루시그니처 </a></li>
+       <li id="1093"><a>미스터힐링</a></li>
+      </ul>
+     </div>
+    </div><span>입니다.</span>
+   </div>
+  </div><!-- //브랜드 선택 영역 --> <!-- 브랜드 상세 혜택 소개 영역 -->
+  <div class="brand-detail">
+   <div class="bd-top">
+    <div class="cate">
+     <span>EAT </span> <span>카페/아이스크림</span> <input type="hidden" name="categoryMid" id="categoryMid" value="55"> <input type="hidden" name="categoryMname" id="categoryMname" value="카페/아이스크림">
+    </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">149819</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="149819"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+   </div>
+   <div class="detail-list">
+    <dl>
+     <dt>
+      혜택
+     </dt>
+     <dd>
+      <dl class="dl-bnf">
+       <dt>
+        할인형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 할인(2,000원)
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 할인(1,200원)
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+        </div>
+       </dd>
+      </dl>
+      <dl class="dl-bnf">
+       <dt>
+        적립형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 적립(2,000P)
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 적립(1,200P)
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+        </div>
+       </dd>
+      </dl>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      유의사항
+     </dt>
+     <dd>
+      <div class="notice">
+       <div class="explain-area pd-no">
+        <ul class="list-dot">
+         <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+         <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+         <li>대상 상품: 싱글레귤러(콘/컵 및 맛 선택 가능, 포장 안 됨)</li>
+         <li>횟수 제한 <br>
+          -할인: 월 1회, 싱글레귤러 1개 <br>
+          -적립: 월 1회, 싱글레귤러 1개 <br>
+          -포인트 사용: T 플러스포인트는 보유하신 한도 내에서 싱글레귤러 주문 시 횟수/수량 제한 없이 사용 가능</li>
+         <li>최대 할인 가능: VIP 2,000원, GOLD/SILVER 1,200원 할인</li>
+         <li>최대 적립 가능: VIP 2,000P, GOLD/SILVER 1,200P 적립</li>
+         <li>다른 행사 및 쿠폰, 제휴 할인과 중복 적용되지 않음</li>
+         <li>할인/적립/사용 금액 제외한 결제 금액의 0.1% 해피포인트 적립</li>
+         <li>모바일 교환권 사용 가능(단, 할인된 모바일 교환권은 사용할 수 없음)</li>
+         <li>매장에 방문하여 현장 구매 시 이용 가능(모바일 주문 및 배달 시 이용할 수 없음)</li>
+         <li>일부 매장 제외 (방문 전 매장 문의 및 배스킨라빈스 홈페이지 참조)</li>
+         <li>적립된 T 플러스포인트는 ‘적립 예정’ 포인트로 표시되며, 결제한 다음 날부터 사용 가능 포인트로 전환</li>
+         <li class="web-link"><a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a></li>
+         <li class="app-link"><a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a></li>
+        </ul>
+       </div>
+      </div>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      문의 및 상담
+     </dt>
+     <dd>
+      <ul class="list-dash">
+       <li>TEL : 080-555-3131</li>
+       <li>HOME : <a href="javascript:goHomePage('')"></a></li>
+      </ul>
+     </dd>
+    </dl>
+   </div>
+  </div>
+ </div><!-- //브랜드 상세 혜택 소개 영역 --> <!-- 비슷한 혜택 브랜드 추천 영역 -->
+ <div class="similar-area">
+  <div class="inr-wrap">
+   <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+   <ul class="benefit-list">
+    <li><a href="javascript:;" class="benefit-box" id="67" data-title="폴 바셋" data-idx="0" data-cate-id="55" data-cate-name="카페/아이스크림">
+      <div class="bnf-top">
+       <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202211/1667888724269.png" alt="폴 바셋"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">폴 바셋</span>
+       <div class="badge-list">
+        <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+       </div>
+      </div>
+      <div class="bnf-info">
+       <dl class="dl-bnf">
+        <dt>
+         할인형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종(사이즈 무관) 구매 시 10% 할인
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+         </div>
+        </dd>
+       </dl>
+       <dl class="dl-bnf">
+        <dt>
+         적립형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피(사이즈 무관) 구매 시 10% 적립
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+         </div>
+        </dd>
+       </dl>
+      </div><span class="btn-round gra">자세히 보기</span> </a></li>
+    <li><a href="javascript:;" class="benefit-box" id="1093" data-title="미스터힐링" data-idx="1" data-cate-id="55" data-cate-name="카페/아이스크림">
+      <div class="bnf-top">
+       <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635300553816.png" alt="미스터힐링"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">미스터힐링</span>
+       <div class="badge-list">
+        <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+       </div>
+      </div>
+      <div class="bnf-info">
+       <dl class="dl-bnf">
+        <dt>
+         할인형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 할인
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+         </div>
+        </dd>
+       </dl>
+       <dl class="dl-bnf">
+        <dt>
+         적립형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 적립
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+         </div>
+        </dd>
+       </dl>
+      </div><span class="btn-round gra">자세히 보기</span> </a></li>
+    <li><a href="javascript:;" class="benefit-box" id="992" data-title="던킨" data-idx="2" data-cate-id="55" data-cate-name="카페/아이스크림">
+      <div class="bnf-top">
+       <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202203/1648185466264.png" alt="던킨"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">던킨</span>
+       <div class="badge-list">
+        <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+       </div>
+      </div>
+      <div class="bnf-info">
+       <dl class="dl-bnf">
+        <dt>
+         할인형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 할인
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 할인
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+         </div>
+        </dd>
+       </dl>
+       <dl class="dl-bnf">
+        <dt>
+         적립형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 적립
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 적립
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+         </div>
+        </dd>
+       </dl>
+      </div><span class="btn-round gra">자세히 보기</span> </a></li>
+   </ul>
+  </div>
+ </div><!-- //비슷한 혜택 브랜드 추천 영역 -->
+</div>
+<div class="inr-wrap">
+ <div class="title-area">
+  <h1>배스킨라빈스</h1><input type="hidden" name="brandId" id="brandId" value="998"> <input type="hidden" name="brandName" id="brandName" value="배스킨라빈스">
+ </div><!-- 브랜드 상단 영역 -->
+ <div class="brnad-info-top">
+  <div class="bit-left">
+   <p class="tit">행복을 전하는 프리미엄 아이스크림, 배스킨라빈스</p>
+   <div class="badge-list">
+    <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+   </div>
+  </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202204/1649135025498.png" alt="배스킨라빈스"> </span>
+ </div><!-- //브랜드 상단 영역 --> <!-- 브랜드 선택 영역 -->
+ <div class="brand-sel-box">
+  <div class="fc-select">
+   <span>고객님이 선택하신 브랜드는</span>
+   <div class="dropdown" data-selectbox>
+    <a href="javascript:;" data-set-button> <span></span></a>
+    <div data-set-list>
+     <ul id="sel-ul">
+      <!-- 선택된 값에 'data-selected' 추가 -->
+      <li id="53"><a>베이커리</a></li>
+      <li id="54"><a>외식</a></li>
+      <li id="55" data-selected="data-selected"><a>카페/아이스크림</a></li>
+      <li id="56"><a>피자/치킨</a></li>
+      <li id="48"><a>금융/통신</a></li>
+      <li id="112"><a>렌탈</a></li>
+      <li id="116"><a>반려동물</a></li>
+      <li id="49"><a>생활/교통</a></li>
+      <li id="50"><a>쇼핑몰</a></li>
+      <li id="51"><a>패션/뷰티</a></li>
+      <li id="52"><a>편의점</a></li>
+      <li id="57"><a>교육</a></li>
+      <li id="109"><a>액티비티</a></li>
+      <li id="59"><a>여행</a></li>
+      <li id="60"><a>영화/공연/전시</a></li>
+      <li id="61"><a>콘텐츠</a></li>
+      <li id="110"><a>테마파크</a></li>
+     </ul>
+    </div>
+   </div>
+   <div class="dropdown" data-selectbox>
+    <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+    <div id="smallList" data-set-list>
+     <ul id="sel-list">
+      <li id="998" data-selected="data-selected"><a>배스킨라빈스</a></li>
+      <li id="771"><a>공차</a></li>
+      <li id="67"><a>폴 바셋</a></li>
+      <li id="992"><a>던킨</a></li>
+      <li id="887"><a>엔제리너스</a></li>
+      <li id="5051"><a>드롭탑</a></li>
+      <li id="961"><a>나뚜루&amp;나뚜루시그니처 </a></li>
+      <li id="1093"><a>미스터힐링</a></li>
+     </ul>
+    </div>
+   </div><span>입니다.</span>
+  </div>
+ </div><!-- //브랜드 선택 영역 --> <!-- 브랜드 상세 혜택 소개 영역 -->
+ <div class="brand-detail">
+  <div class="bd-top">
+   <div class="cate">
+    <span>EAT </span> <span>카페/아이스크림</span> <input type="hidden" name="categoryMid" id="categoryMid" value="55"> <input type="hidden" name="categoryMname" id="categoryMname" value="카페/아이스크림">
+   </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">149819</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="149819"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+  </div>
+  <div class="detail-list">
+   <dl>
+    <dt>
+     혜택
+    </dt>
+    <dd>
+     <dl class="dl-bnf">
+      <dt>
+       할인형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 할인(2,000원)
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 할인(1,200원)
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+       </div>
+      </dd>
+     </dl>
+     <dl class="dl-bnf">
+      <dt>
+       적립형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 적립(2,000P)
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 적립(1,200P)
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+       </div>
+      </dd>
+     </dl>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     유의사항
+    </dt>
+    <dd>
+     <div class="notice">
+      <div class="explain-area pd-no">
+       <ul class="list-dot">
+        <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+        <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+        <li>대상 상품: 싱글레귤러(콘/컵 및 맛 선택 가능, 포장 안 됨)</li>
+        <li>횟수 제한 <br>
+         -할인: 월 1회, 싱글레귤러 1개 <br>
+         -적립: 월 1회, 싱글레귤러 1개 <br>
+         -포인트 사용: T 플러스포인트는 보유하신 한도 내에서 싱글레귤러 주문 시 횟수/수량 제한 없이 사용 가능</li>
+        <li>최대 할인 가능: VIP 2,000원, GOLD/SILVER 1,200원 할인</li>
+        <li>최대 적립 가능: VIP 2,000P, GOLD/SILVER 1,200P 적립</li>
+        <li>다른 행사 및 쿠폰, 제휴 할인과 중복 적용되지 않음</li>
+        <li>할인/적립/사용 금액 제외한 결제 금액의 0.1% 해피포인트 적립</li>
+        <li>모바일 교환권 사용 가능(단, 할인된 모바일 교환권은 사용할 수 없음)</li>
+        <li>매장에 방문하여 현장 구매 시 이용 가능(모바일 주문 및 배달 시 이용할 수 없음)</li>
+        <li>일부 매장 제외 (방문 전 매장 문의 및 배스킨라빈스 홈페이지 참조)</li>
+        <li>적립된 T 플러스포인트는 ‘적립 예정’ 포인트로 표시되며, 결제한 다음 날부터 사용 가능 포인트로 전환</li>
+        <li class="web-link"><a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a></li>
+        <li class="app-link"><a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a></li>
+       </ul>
+      </div>
+     </div>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     문의 및 상담
+    </dt>
+    <dd>
+     <ul class="list-dash">
+      <li>TEL : 080-555-3131</li>
+      <li>HOME : <a href="javascript:goHomePage('')"></a></li>
+     </ul>
+    </dd>
+   </dl>
+  </div>
+ </div>
+</div>
+<div class="title-area">
+ <h1>배스킨라빈스</h1><input type="hidden" name="brandId" id="brandId" value="998"> <input type="hidden" name="brandName" id="brandName" value="배스킨라빈스">
+</div>
+<h1>배스킨라빈스</h1>
+<input type="hidden" name="brandId" id="brandId" value="998">
+<input type="hidden" name="brandName" id="brandName" value="배스킨라빈스">
+<div class="brnad-info-top">
+ <div class="bit-left">
+  <p class="tit">행복을 전하는 프리미엄 아이스크림, 배스킨라빈스</p>
+  <div class="badge-list">
+   <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+  </div>
+ </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202204/1649135025498.png" alt="배스킨라빈스"> </span>
+</div>
+<div class="bit-left">
+ <p class="tit">행복을 전하는 프리미엄 아이스크림, 배스킨라빈스</p>
+ <div class="badge-list">
+  <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+ </div>
+</div>
+<p class="tit">행복을 전하는 프리미엄 아이스크림, 배스킨라빈스</p>
+<div class="badge-list">
+ <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+</div>
+<i class="badge-bg-radius skyBlue">할인</i>
+<i class="badge-bg-radius pink">적립</i>
+<i class="badge-bg-radius skyBlue">사용</i>
+<span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202204/1649135025498.png" alt="배스킨라빈스"> </span>
+<img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202204/1649135025498.png" alt="배스킨라빈스">
+<div class="brand-sel-box">
+ <div class="fc-select">
+  <span>고객님이 선택하신 브랜드는</span>
+  <div class="dropdown" data-selectbox>
+   <a href="javascript:;" data-set-button> <span></span></a>
+   <div data-set-list>
+    <ul id="sel-ul">
+     <!-- 선택된 값에 'data-selected' 추가 -->
+     <li id="53"><a>베이커리</a></li>
+     <li id="54"><a>외식</a></li>
+     <li id="55" data-selected="data-selected"><a>카페/아이스크림</a></li>
+     <li id="56"><a>피자/치킨</a></li>
+     <li id="48"><a>금융/통신</a></li>
+     <li id="112"><a>렌탈</a></li>
+     <li id="116"><a>반려동물</a></li>
+     <li id="49"><a>생활/교통</a></li>
+     <li id="50"><a>쇼핑몰</a></li>
+     <li id="51"><a>패션/뷰티</a></li>
+     <li id="52"><a>편의점</a></li>
+     <li id="57"><a>교육</a></li>
+     <li id="109"><a>액티비티</a></li>
+     <li id="59"><a>여행</a></li>
+     <li id="60"><a>영화/공연/전시</a></li>
+     <li id="61"><a>콘텐츠</a></li>
+     <li id="110"><a>테마파크</a></li>
+    </ul>
+   </div>
+  </div>
+  <div class="dropdown" data-selectbox>
+   <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+   <div id="smallList" data-set-list>
+    <ul id="sel-list">
+     <li id="998" data-selected="data-selected"><a>배스킨라빈스</a></li>
+     <li id="771"><a>공차</a></li>
+     <li id="67"><a>폴 바셋</a></li>
+     <li id="992"><a>던킨</a></li>
+     <li id="887"><a>엔제리너스</a></li>
+     <li id="5051"><a>드롭탑</a></li>
+     <li id="961"><a>나뚜루&amp;나뚜루시그니처 </a></li>
+     <li id="1093"><a>미스터힐링</a></li>
+    </ul>
+   </div>
+  </div><span>입니다.</span>
+ </div>
+</div>
+<div class="fc-select">
+ <span>고객님이 선택하신 브랜드는</span>
+ <div class="dropdown" data-selectbox>
+  <a href="javascript:;" data-set-button> <span></span></a>
+  <div data-set-list>
+   <ul id="sel-ul">
+    <!-- 선택된 값에 'data-selected' 추가 -->
+    <li id="53"><a>베이커리</a></li>
+    <li id="54"><a>외식</a></li>
+    <li id="55" data-selected="data-selected"><a>카페/아이스크림</a></li>
+    <li id="56"><a>피자/치킨</a></li>
+    <li id="48"><a>금융/통신</a></li>
+    <li id="112"><a>렌탈</a></li>
+    <li id="116"><a>반려동물</a></li>
+    <li id="49"><a>생활/교통</a></li>
+    <li id="50"><a>쇼핑몰</a></li>
+    <li id="51"><a>패션/뷰티</a></li>
+    <li id="52"><a>편의점</a></li>
+    <li id="57"><a>교육</a></li>
+    <li id="109"><a>액티비티</a></li>
+    <li id="59"><a>여행</a></li>
+    <li id="60"><a>영화/공연/전시</a></li>
+    <li id="61"><a>콘텐츠</a></li>
+    <li id="110"><a>테마파크</a></li>
+   </ul>
+  </div>
+ </div>
+ <div class="dropdown" data-selectbox>
+  <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+  <div id="smallList" data-set-list>
+   <ul id="sel-list">
+    <li id="998" data-selected="data-selected"><a>배스킨라빈스</a></li>
+    <li id="771"><a>공차</a></li>
+    <li id="67"><a>폴 바셋</a></li>
+    <li id="992"><a>던킨</a></li>
+    <li id="887"><a>엔제리너스</a></li>
+    <li id="5051"><a>드롭탑</a></li>
+    <li id="961"><a>나뚜루&amp;나뚜루시그니처 </a></li>
+    <li id="1093"><a>미스터힐링</a></li>
+   </ul>
+  </div>
+ </div><span>입니다.</span>
+</div>
+<span>고객님이 선택하신 브랜드는</span>
+<div class="dropdown" data-selectbox>
+ <a href="javascript:;" data-set-button> <span></span></a>
+ <div data-set-list>
+  <ul id="sel-ul">
+   <!-- 선택된 값에 'data-selected' 추가 -->
+   <li id="53"><a>베이커리</a></li>
+   <li id="54"><a>외식</a></li>
+   <li id="55" data-selected="data-selected"><a>카페/아이스크림</a></li>
+   <li id="56"><a>피자/치킨</a></li>
+   <li id="48"><a>금융/통신</a></li>
+   <li id="112"><a>렌탈</a></li>
+   <li id="116"><a>반려동물</a></li>
+   <li id="49"><a>생활/교통</a></li>
+   <li id="50"><a>쇼핑몰</a></li>
+   <li id="51"><a>패션/뷰티</a></li>
+   <li id="52"><a>편의점</a></li>
+   <li id="57"><a>교육</a></li>
+   <li id="109"><a>액티비티</a></li>
+   <li id="59"><a>여행</a></li>
+   <li id="60"><a>영화/공연/전시</a></li>
+   <li id="61"><a>콘텐츠</a></li>
+   <li id="110"><a>테마파크</a></li>
+  </ul>
+ </div>
+</div>
+<a href="javascript:;" data-set-button> <span></span></a>
+<span></span>
+<div data-set-list>
+ <ul id="sel-ul">
+  <!-- 선택된 값에 'data-selected' 추가 -->
+  <li id="53"><a>베이커리</a></li>
+  <li id="54"><a>외식</a></li>
+  <li id="55" data-selected="data-selected"><a>카페/아이스크림</a></li>
+  <li id="56"><a>피자/치킨</a></li>
+  <li id="48"><a>금융/통신</a></li>
+  <li id="112"><a>렌탈</a></li>
+  <li id="116"><a>반려동물</a></li>
+  <li id="49"><a>생활/교통</a></li>
+  <li id="50"><a>쇼핑몰</a></li>
+  <li id="51"><a>패션/뷰티</a></li>
+  <li id="52"><a>편의점</a></li>
+  <li id="57"><a>교육</a></li>
+  <li id="109"><a>액티비티</a></li>
+  <li id="59"><a>여행</a></li>
+  <li id="60"><a>영화/공연/전시</a></li>
+  <li id="61"><a>콘텐츠</a></li>
+  <li id="110"><a>테마파크</a></li>
+ </ul>
+</div>
+<ul id="sel-ul">
+ <!-- 선택된 값에 'data-selected' 추가 -->
+ <li id="53"><a>베이커리</a></li>
+ <li id="54"><a>외식</a></li>
+ <li id="55" data-selected="data-selected"><a>카페/아이스크림</a></li>
+ <li id="56"><a>피자/치킨</a></li>
+ <li id="48"><a>금융/통신</a></li>
+ <li id="112"><a>렌탈</a></li>
+ <li id="116"><a>반려동물</a></li>
+ <li id="49"><a>생활/교통</a></li>
+ <li id="50"><a>쇼핑몰</a></li>
+ <li id="51"><a>패션/뷰티</a></li>
+ <li id="52"><a>편의점</a></li>
+ <li id="57"><a>교육</a></li>
+ <li id="109"><a>액티비티</a></li>
+ <li id="59"><a>여행</a></li>
+ <li id="60"><a>영화/공연/전시</a></li>
+ <li id="61"><a>콘텐츠</a></li>
+ <li id="110"><a>테마파크</a></li>
+</ul>
+<li id="53"><a>베이커리</a></li>
+<a>베이커리</a>
+<li id="54"><a>외식</a></li>
+<a>외식</a>
+<li id="55" data-selected="data-selected"><a>카페/아이스크림</a></li>
+<a>카페/아이스크림</a>
+<li id="56"><a>피자/치킨</a></li>
+<a>피자/치킨</a>
+<li id="48"><a>금융/통신</a></li>
+<a>금융/통신</a>
+<li id="112"><a>렌탈</a></li>
+<a>렌탈</a>
+<li id="116"><a>반려동물</a></li>
+<a>반려동물</a>
+<li id="49"><a>생활/교통</a></li>
+<a>생활/교통</a>
+<li id="50"><a>쇼핑몰</a></li>
+<a>쇼핑몰</a>
+<li id="51"><a>패션/뷰티</a></li>
+<a>패션/뷰티</a>
+<li id="52"><a>편의점</a></li>
+<a>편의점</a>
+<li id="57"><a>교육</a></li>
+<a>교육</a>
+<li id="109"><a>액티비티</a></li>
+<a>액티비티</a>
+<li id="59"><a>여행</a></li>
+<a>여행</a>
+<li id="60"><a>영화/공연/전시</a></li>
+<a>영화/공연/전시</a>
+<li id="61"><a>콘텐츠</a></li>
+<a>콘텐츠</a>
+<li id="110"><a>테마파크</a></li>
+<a>테마파크</a>
+<div class="dropdown" data-selectbox>
+ <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+ <div id="smallList" data-set-list>
+  <ul id="sel-list">
+   <li id="998" data-selected="data-selected"><a>배스킨라빈스</a></li>
+   <li id="771"><a>공차</a></li>
+   <li id="67"><a>폴 바셋</a></li>
+   <li id="992"><a>던킨</a></li>
+   <li id="887"><a>엔제리너스</a></li>
+   <li id="5051"><a>드롭탑</a></li>
+   <li id="961"><a>나뚜루&amp;나뚜루시그니처 </a></li>
+   <li id="1093"><a>미스터힐링</a></li>
+  </ul>
+ </div>
+</div>
+<a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+<span></span>
+<div id="smallList" data-set-list>
+ <ul id="sel-list">
+  <li id="998" data-selected="data-selected"><a>배스킨라빈스</a></li>
+  <li id="771"><a>공차</a></li>
+  <li id="67"><a>폴 바셋</a></li>
+  <li id="992"><a>던킨</a></li>
+  <li id="887"><a>엔제리너스</a></li>
+  <li id="5051"><a>드롭탑</a></li>
+  <li id="961"><a>나뚜루&amp;나뚜루시그니처 </a></li>
+  <li id="1093"><a>미스터힐링</a></li>
+ </ul>
+</div>
+<ul id="sel-list">
+ <li id="998" data-selected="data-selected"><a>배스킨라빈스</a></li>
+ <li id="771"><a>공차</a></li>
+ <li id="67"><a>폴 바셋</a></li>
+ <li id="992"><a>던킨</a></li>
+ <li id="887"><a>엔제리너스</a></li>
+ <li id="5051"><a>드롭탑</a></li>
+ <li id="961"><a>나뚜루&amp;나뚜루시그니처 </a></li>
+ <li id="1093"><a>미스터힐링</a></li>
+</ul>
+<li id="998" data-selected="data-selected"><a>배스킨라빈스</a></li>
+<a>배스킨라빈스</a>
+<li id="771"><a>공차</a></li>
+<a>공차</a>
+<li id="67"><a>폴 바셋</a></li>
+<a>폴 바셋</a>
+<li id="992"><a>던킨</a></li>
+<a>던킨</a>
+<li id="887"><a>엔제리너스</a></li>
+<a>엔제리너스</a>
+<li id="5051"><a>드롭탑</a></li>
+<a>드롭탑</a>
+<li id="961"><a>나뚜루&amp;나뚜루시그니처 </a></li>
+<a>나뚜루&amp;나뚜루시그니처 </a>
+<li id="1093"><a>미스터힐링</a></li>
+<a>미스터힐링</a>
+<span>입니다.</span>
+<div class="brand-detail">
+ <div class="bd-top">
+  <div class="cate">
+   <span>EAT </span> <span>카페/아이스크림</span> <input type="hidden" name="categoryMid" id="categoryMid" value="55"> <input type="hidden" name="categoryMname" id="categoryMname" value="카페/아이스크림">
+  </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">149819</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="149819"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+ </div>
+ <div class="detail-list">
+  <dl>
+   <dt>
+    혜택
+   </dt>
+   <dd>
+    <dl class="dl-bnf">
+     <dt>
+      할인형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 할인(2,000원)
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 할인(1,200원)
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+      </div>
+     </dd>
+    </dl>
+    <dl class="dl-bnf">
+     <dt>
+      적립형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 적립(2,000P)
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 적립(1,200P)
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+      </div>
+     </dd>
+    </dl>
+   </dd>
+  </dl>
+  <dl>
+   <dt>
+    유의사항
+   </dt>
+   <dd>
+    <div class="notice">
+     <div class="explain-area pd-no">
+      <ul class="list-dot">
+       <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+       <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+       <li>대상 상품: 싱글레귤러(콘/컵 및 맛 선택 가능, 포장 안 됨)</li>
+       <li>횟수 제한 <br>
+        -할인: 월 1회, 싱글레귤러 1개 <br>
+        -적립: 월 1회, 싱글레귤러 1개 <br>
+        -포인트 사용: T 플러스포인트는 보유하신 한도 내에서 싱글레귤러 주문 시 횟수/수량 제한 없이 사용 가능</li>
+       <li>최대 할인 가능: VIP 2,000원, GOLD/SILVER 1,200원 할인</li>
+       <li>최대 적립 가능: VIP 2,000P, GOLD/SILVER 1,200P 적립</li>
+       <li>다른 행사 및 쿠폰, 제휴 할인과 중복 적용되지 않음</li>
+       <li>할인/적립/사용 금액 제외한 결제 금액의 0.1% 해피포인트 적립</li>
+       <li>모바일 교환권 사용 가능(단, 할인된 모바일 교환권은 사용할 수 없음)</li>
+       <li>매장에 방문하여 현장 구매 시 이용 가능(모바일 주문 및 배달 시 이용할 수 없음)</li>
+       <li>일부 매장 제외 (방문 전 매장 문의 및 배스킨라빈스 홈페이지 참조)</li>
+       <li>적립된 T 플러스포인트는 ‘적립 예정’ 포인트로 표시되며, 결제한 다음 날부터 사용 가능 포인트로 전환</li>
+       <li class="web-link"><a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a></li>
+       <li class="app-link"><a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a></li>
+      </ul>
+     </div>
+    </div>
+   </dd>
+  </dl>
+  <dl>
+   <dt>
+    문의 및 상담
+   </dt>
+   <dd>
+    <ul class="list-dash">
+     <li>TEL : 080-555-3131</li>
+     <li>HOME : <a href="javascript:goHomePage('')"></a></li>
+    </ul>
+   </dd>
+  </dl>
+ </div>
+</div>
+<div class="bd-top">
+ <div class="cate">
+  <span>EAT </span> <span>카페/아이스크림</span> <input type="hidden" name="categoryMid" id="categoryMid" value="55"> <input type="hidden" name="categoryMname" id="categoryMname" value="카페/아이스크림">
+ </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">149819</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="149819"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+</div>
+<div class="cate">
+ <span>EAT </span> <span>카페/아이스크림</span> <input type="hidden" name="categoryMid" id="categoryMid" value="55"> <input type="hidden" name="categoryMname" id="categoryMname" value="카페/아이스크림">
+</div>
+<span>EAT </span>
+<span>카페/아이스크림</span>
+<input type="hidden" name="categoryMid" id="categoryMid" value="55">
+<input type="hidden" name="categoryMname" id="categoryMname" value="카페/아이스크림">
+<button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">149819</span></button>
+<i class="ico-heart"></i>
+<span id="favoriteNewCount">149819</span>
+<input type="hidden" name="favoriteCount" id="favoriteCount" value="149819">
+<input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+<div class="detail-list">
+ <dl>
+  <dt>
+   혜택
+  </dt>
+  <dd>
+   <dl class="dl-bnf">
+    <dt>
+     할인형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 할인(2,000원)
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 할인(1,200원)
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+     </div>
+    </dd>
+   </dl>
+   <dl class="dl-bnf">
+    <dt>
+     적립형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 적립(2,000P)
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 적립(1,200P)
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+     </div>
+    </dd>
+   </dl>
+  </dd>
+ </dl>
+ <dl>
+  <dt>
+   유의사항
+  </dt>
+  <dd>
+   <div class="notice">
+    <div class="explain-area pd-no">
+     <ul class="list-dot">
+      <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+      <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+      <li>대상 상품: 싱글레귤러(콘/컵 및 맛 선택 가능, 포장 안 됨)</li>
+      <li>횟수 제한 <br>
+       -할인: 월 1회, 싱글레귤러 1개 <br>
+       -적립: 월 1회, 싱글레귤러 1개 <br>
+       -포인트 사용: T 플러스포인트는 보유하신 한도 내에서 싱글레귤러 주문 시 횟수/수량 제한 없이 사용 가능</li>
+      <li>최대 할인 가능: VIP 2,000원, GOLD/SILVER 1,200원 할인</li>
+      <li>최대 적립 가능: VIP 2,000P, GOLD/SILVER 1,200P 적립</li>
+      <li>다른 행사 및 쿠폰, 제휴 할인과 중복 적용되지 않음</li>
+      <li>할인/적립/사용 금액 제외한 결제 금액의 0.1% 해피포인트 적립</li>
+      <li>모바일 교환권 사용 가능(단, 할인된 모바일 교환권은 사용할 수 없음)</li>
+      <li>매장에 방문하여 현장 구매 시 이용 가능(모바일 주문 및 배달 시 이용할 수 없음)</li>
+      <li>일부 매장 제외 (방문 전 매장 문의 및 배스킨라빈스 홈페이지 참조)</li>
+      <li>적립된 T 플러스포인트는 ‘적립 예정’ 포인트로 표시되며, 결제한 다음 날부터 사용 가능 포인트로 전환</li>
+      <li class="web-link"><a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a></li>
+      <li class="app-link"><a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a></li>
+     </ul>
+    </div>
+   </div>
+  </dd>
+ </dl>
+ <dl>
+  <dt>
+   문의 및 상담
+  </dt>
+  <dd>
+   <ul class="list-dash">
+    <li>TEL : 080-555-3131</li>
+    <li>HOME : <a href="javascript:goHomePage('')"></a></li>
+   </ul>
+  </dd>
+ </dl>
+</div>
+<dl>
+ <dt>
+  혜택
+ </dt>
+ <dd>
+  <dl class="dl-bnf">
+   <dt>
+    할인형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 할인(2,000원)
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 할인(1,200원)
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+    </div>
+   </dd>
+  </dl>
+  <dl class="dl-bnf">
+   <dt>
+    적립형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 적립(2,000P)
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 적립(1,200P)
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+    </div>
+   </dd>
+  </dl>
+ </dd>
+</dl>
+<dt>
+ 혜택
+</dt>
+<dd>
+ <dl class="dl-bnf">
+  <dt>
+   할인형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 할인(2,000원)
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 할인(1,200원)
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+   </div>
+  </dd>
+ </dl>
+ <dl class="dl-bnf">
+  <dt>
+   적립형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 적립(2,000P)
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 적립(1,200P)
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+   </div>
+  </dd>
+ </dl>
+</dd>
+<dl class="dl-bnf">
+ <dt>
+  할인형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 할인(2,000원)
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 할인(1,200원)
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+  </div>
+ </dd>
+</dl>
+<dt>
+ 할인형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 할인(2,000원)
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 할인(1,200원)
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 할인(2,000원)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 할인(1,200원)
+</div>
+<span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<dl class="dl-bnf">
+ <dt>
+  적립형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 적립(2,000P)
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 적립(1,200P)
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+  </div>
+ </dd>
+</dl>
+<dt>
+ 적립형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 적립(2,000P)
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 적립(1,200P)
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span> 50% 적립(2,000P)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 30% 적립(1,200P)
+</div>
+<span class="badge-list"> <i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용 가능(100%, 10P 단위)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<i class="badge-circle lite"><span class="blind">L</span></i>
+<span class="blind">L</span>
+<dl>
+ <dt>
+  유의사항
+ </dt>
+ <dd>
+  <div class="notice">
+   <div class="explain-area pd-no">
+    <ul class="list-dot">
+     <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+     <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+     <li>대상 상품: 싱글레귤러(콘/컵 및 맛 선택 가능, 포장 안 됨)</li>
+     <li>횟수 제한 <br>
+      -할인: 월 1회, 싱글레귤러 1개 <br>
+      -적립: 월 1회, 싱글레귤러 1개 <br>
+      -포인트 사용: T 플러스포인트는 보유하신 한도 내에서 싱글레귤러 주문 시 횟수/수량 제한 없이 사용 가능</li>
+     <li>최대 할인 가능: VIP 2,000원, GOLD/SILVER 1,200원 할인</li>
+     <li>최대 적립 가능: VIP 2,000P, GOLD/SILVER 1,200P 적립</li>
+     <li>다른 행사 및 쿠폰, 제휴 할인과 중복 적용되지 않음</li>
+     <li>할인/적립/사용 금액 제외한 결제 금액의 0.1% 해피포인트 적립</li>
+     <li>모바일 교환권 사용 가능(단, 할인된 모바일 교환권은 사용할 수 없음)</li>
+     <li>매장에 방문하여 현장 구매 시 이용 가능(모바일 주문 및 배달 시 이용할 수 없음)</li>
+     <li>일부 매장 제외 (방문 전 매장 문의 및 배스킨라빈스 홈페이지 참조)</li>
+     <li>적립된 T 플러스포인트는 ‘적립 예정’ 포인트로 표시되며, 결제한 다음 날부터 사용 가능 포인트로 전환</li>
+     <li class="web-link"><a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a></li>
+     <li class="app-link"><a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a></li>
+    </ul>
+   </div>
+  </div>
+ </dd>
+</dl>
+<dt>
+ 유의사항
+</dt>
+<dd>
+ <div class="notice">
+  <div class="explain-area pd-no">
+   <ul class="list-dot">
+    <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+    <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+    <li>대상 상품: 싱글레귤러(콘/컵 및 맛 선택 가능, 포장 안 됨)</li>
+    <li>횟수 제한 <br>
+     -할인: 월 1회, 싱글레귤러 1개 <br>
+     -적립: 월 1회, 싱글레귤러 1개 <br>
+     -포인트 사용: T 플러스포인트는 보유하신 한도 내에서 싱글레귤러 주문 시 횟수/수량 제한 없이 사용 가능</li>
+    <li>최대 할인 가능: VIP 2,000원, GOLD/SILVER 1,200원 할인</li>
+    <li>최대 적립 가능: VIP 2,000P, GOLD/SILVER 1,200P 적립</li>
+    <li>다른 행사 및 쿠폰, 제휴 할인과 중복 적용되지 않음</li>
+    <li>할인/적립/사용 금액 제외한 결제 금액의 0.1% 해피포인트 적립</li>
+    <li>모바일 교환권 사용 가능(단, 할인된 모바일 교환권은 사용할 수 없음)</li>
+    <li>매장에 방문하여 현장 구매 시 이용 가능(모바일 주문 및 배달 시 이용할 수 없음)</li>
+    <li>일부 매장 제외 (방문 전 매장 문의 및 배스킨라빈스 홈페이지 참조)</li>
+    <li>적립된 T 플러스포인트는 ‘적립 예정’ 포인트로 표시되며, 결제한 다음 날부터 사용 가능 포인트로 전환</li>
+    <li class="web-link"><a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a></li>
+    <li class="app-link"><a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a></li>
+   </ul>
+  </div>
+ </div>
+</dd>
+<div class="notice">
+ <div class="explain-area pd-no">
+  <ul class="list-dot">
+   <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+   <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+   <li>대상 상품: 싱글레귤러(콘/컵 및 맛 선택 가능, 포장 안 됨)</li>
+   <li>횟수 제한 <br>
+    -할인: 월 1회, 싱글레귤러 1개 <br>
+    -적립: 월 1회, 싱글레귤러 1개 <br>
+    -포인트 사용: T 플러스포인트는 보유하신 한도 내에서 싱글레귤러 주문 시 횟수/수량 제한 없이 사용 가능</li>
+   <li>최대 할인 가능: VIP 2,000원, GOLD/SILVER 1,200원 할인</li>
+   <li>최대 적립 가능: VIP 2,000P, GOLD/SILVER 1,200P 적립</li>
+   <li>다른 행사 및 쿠폰, 제휴 할인과 중복 적용되지 않음</li>
+   <li>할인/적립/사용 금액 제외한 결제 금액의 0.1% 해피포인트 적립</li>
+   <li>모바일 교환권 사용 가능(단, 할인된 모바일 교환권은 사용할 수 없음)</li>
+   <li>매장에 방문하여 현장 구매 시 이용 가능(모바일 주문 및 배달 시 이용할 수 없음)</li>
+   <li>일부 매장 제외 (방문 전 매장 문의 및 배스킨라빈스 홈페이지 참조)</li>
+   <li>적립된 T 플러스포인트는 ‘적립 예정’ 포인트로 표시되며, 결제한 다음 날부터 사용 가능 포인트로 전환</li>
+   <li class="web-link"><a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a></li>
+   <li class="app-link"><a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a></li>
+  </ul>
+ </div>
+</div>
+<div class="explain-area pd-no">
+ <ul class="list-dot">
+  <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+  <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+  <li>대상 상품: 싱글레귤러(콘/컵 및 맛 선택 가능, 포장 안 됨)</li>
+  <li>횟수 제한 <br>
+   -할인: 월 1회, 싱글레귤러 1개 <br>
+   -적립: 월 1회, 싱글레귤러 1개 <br>
+   -포인트 사용: T 플러스포인트는 보유하신 한도 내에서 싱글레귤러 주문 시 횟수/수량 제한 없이 사용 가능</li>
+  <li>최대 할인 가능: VIP 2,000원, GOLD/SILVER 1,200원 할인</li>
+  <li>최대 적립 가능: VIP 2,000P, GOLD/SILVER 1,200P 적립</li>
+  <li>다른 행사 및 쿠폰, 제휴 할인과 중복 적용되지 않음</li>
+  <li>할인/적립/사용 금액 제외한 결제 금액의 0.1% 해피포인트 적립</li>
+  <li>모바일 교환권 사용 가능(단, 할인된 모바일 교환권은 사용할 수 없음)</li>
+  <li>매장에 방문하여 현장 구매 시 이용 가능(모바일 주문 및 배달 시 이용할 수 없음)</li>
+  <li>일부 매장 제외 (방문 전 매장 문의 및 배스킨라빈스 홈페이지 참조)</li>
+  <li>적립된 T 플러스포인트는 ‘적립 예정’ 포인트로 표시되며, 결제한 다음 날부터 사용 가능 포인트로 전환</li>
+  <li class="web-link"><a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a></li>
+  <li class="app-link"><a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a></li>
+ </ul>
+</div>
+<ul class="list-dot">
+ <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+ <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+ <li>대상 상품: 싱글레귤러(콘/컵 및 맛 선택 가능, 포장 안 됨)</li>
+ <li>횟수 제한 <br>
+  -할인: 월 1회, 싱글레귤러 1개 <br>
+  -적립: 월 1회, 싱글레귤러 1개 <br>
+  -포인트 사용: T 플러스포인트는 보유하신 한도 내에서 싱글레귤러 주문 시 횟수/수량 제한 없이 사용 가능</li>
+ <li>최대 할인 가능: VIP 2,000원, GOLD/SILVER 1,200원 할인</li>
+ <li>최대 적립 가능: VIP 2,000P, GOLD/SILVER 1,200P 적립</li>
+ <li>다른 행사 및 쿠폰, 제휴 할인과 중복 적용되지 않음</li>
+ <li>할인/적립/사용 금액 제외한 결제 금액의 0.1% 해피포인트 적립</li>
+ <li>모바일 교환권 사용 가능(단, 할인된 모바일 교환권은 사용할 수 없음)</li>
+ <li>매장에 방문하여 현장 구매 시 이용 가능(모바일 주문 및 배달 시 이용할 수 없음)</li>
+ <li>일부 매장 제외 (방문 전 매장 문의 및 배스킨라빈스 홈페이지 참조)</li>
+ <li>적립된 T 플러스포인트는 ‘적립 예정’ 포인트로 표시되며, 결제한 다음 날부터 사용 가능 포인트로 전환</li>
+ <li class="web-link"><a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a></li>
+ <li class="app-link"><a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a></li>
+</ul>
+<li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+<li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+<li>대상 상품: 싱글레귤러(콘/컵 및 맛 선택 가능, 포장 안 됨)</li>
+<li>횟수 제한 <br>
+ -할인: 월 1회, 싱글레귤러 1개 <br>
+ -적립: 월 1회, 싱글레귤러 1개 <br>
+ -포인트 사용: T 플러스포인트는 보유하신 한도 내에서 싱글레귤러 주문 시 횟수/수량 제한 없이 사용 가능</li>
+<br>
+<br>
+<br>
+<li>최대 할인 가능: VIP 2,000원, GOLD/SILVER 1,200원 할인</li>
+<li>최대 적립 가능: VIP 2,000P, GOLD/SILVER 1,200P 적립</li>
+<li>다른 행사 및 쿠폰, 제휴 할인과 중복 적용되지 않음</li>
+<li>할인/적립/사용 금액 제외한 결제 금액의 0.1% 해피포인트 적립</li>
+<li>모바일 교환권 사용 가능(단, 할인된 모바일 교환권은 사용할 수 없음)</li>
+<li>매장에 방문하여 현장 구매 시 이용 가능(모바일 주문 및 배달 시 이용할 수 없음)</li>
+<li>일부 매장 제외 (방문 전 매장 문의 및 배스킨라빈스 홈페이지 참조)</li>
+<li>적립된 T 플러스포인트는 ‘적립 예정’ 포인트로 표시되며, 결제한 다음 날부터 사용 가능 포인트로 전환</li>
+<li class="web-link"><a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a></li>
+<a href="https://www.baskinrobbins.co.kr/" target="_blank" title="새창열림">홈페이지 바로가기 ▶</a>
+<li class="app-link"><a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a></li>
+<a onclick="commAppMobileFnc('JSOpenUrl', {function : 'JSOpenUrl','url':'https://www.baskinrobbins.co.kr/'});">홈페이지 바로가기 ▶</a>
+<dl>
+ <dt>
+  문의 및 상담
+ </dt>
+ <dd>
+  <ul class="list-dash">
+   <li>TEL : 080-555-3131</li>
+   <li>HOME : <a href="javascript:goHomePage('')"></a></li>
+  </ul>
+ </dd>
+</dl>
+<dt>
+ 문의 및 상담
+</dt>
+<dd>
+ <ul class="list-dash">
+  <li>TEL : 080-555-3131</li>
+  <li>HOME : <a href="javascript:goHomePage('')"></a></li>
+ </ul>
+</dd>
+<ul class="list-dash">
+ <li>TEL : 080-555-3131</li>
+ <li>HOME : <a href="javascript:goHomePage('')"></a></li>
+</ul>
+<li>TEL : 080-555-3131</li>
+<li>HOME : <a href="javascript:goHomePage('')"></a></li>
+<a href="javascript:goHomePage('')"></a>
+<div class="similar-area">
+ <div class="inr-wrap">
+  <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+  <ul class="benefit-list">
+   <li><a href="javascript:;" class="benefit-box" id="67" data-title="폴 바셋" data-idx="0" data-cate-id="55" data-cate-name="카페/아이스크림">
+     <div class="bnf-top">
+      <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202211/1667888724269.png" alt="폴 바셋"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">폴 바셋</span>
+      <div class="badge-list">
+       <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+      </div>
+     </div>
+     <div class="bnf-info">
+      <dl class="dl-bnf">
+       <dt>
+        할인형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종(사이즈 무관) 구매 시 10% 할인
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+        </div>
+       </dd>
+      </dl>
+      <dl class="dl-bnf">
+       <dt>
+        적립형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피(사이즈 무관) 구매 시 10% 적립
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+        </div>
+       </dd>
+      </dl>
+     </div><span class="btn-round gra">자세히 보기</span> </a></li>
+   <li><a href="javascript:;" class="benefit-box" id="1093" data-title="미스터힐링" data-idx="1" data-cate-id="55" data-cate-name="카페/아이스크림">
+     <div class="bnf-top">
+      <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635300553816.png" alt="미스터힐링"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">미스터힐링</span>
+      <div class="badge-list">
+       <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+      </div>
+     </div>
+     <div class="bnf-info">
+      <dl class="dl-bnf">
+       <dt>
+        할인형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 할인
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+        </div>
+       </dd>
+      </dl>
+      <dl class="dl-bnf">
+       <dt>
+        적립형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 적립
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+        </div>
+       </dd>
+      </dl>
+     </div><span class="btn-round gra">자세히 보기</span> </a></li>
+   <li><a href="javascript:;" class="benefit-box" id="992" data-title="던킨" data-idx="2" data-cate-id="55" data-cate-name="카페/아이스크림">
+     <div class="bnf-top">
+      <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202203/1648185466264.png" alt="던킨"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">던킨</span>
+      <div class="badge-list">
+       <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+      </div>
+     </div>
+     <div class="bnf-info">
+      <dl class="dl-bnf">
+       <dt>
+        할인형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 할인
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 할인
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+        </div>
+       </dd>
+      </dl>
+      <dl class="dl-bnf">
+       <dt>
+        적립형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 적립
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 적립
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+        </div>
+       </dd>
+      </dl>
+     </div><span class="btn-round gra">자세히 보기</span> </a></li>
+  </ul>
+ </div>
+</div>
+<div class="inr-wrap">
+ <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+ <ul class="benefit-list">
+  <li><a href="javascript:;" class="benefit-box" id="67" data-title="폴 바셋" data-idx="0" data-cate-id="55" data-cate-name="카페/아이스크림">
+    <div class="bnf-top">
+     <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202211/1667888724269.png" alt="폴 바셋"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">폴 바셋</span>
+     <div class="badge-list">
+      <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+     </div>
+    </div>
+    <div class="bnf-info">
+     <dl class="dl-bnf">
+      <dt>
+       할인형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종(사이즈 무관) 구매 시 10% 할인
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+       </div>
+      </dd>
+     </dl>
+     <dl class="dl-bnf">
+      <dt>
+       적립형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피(사이즈 무관) 구매 시 10% 적립
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+       </div>
+      </dd>
+     </dl>
+    </div><span class="btn-round gra">자세히 보기</span> </a></li>
+  <li><a href="javascript:;" class="benefit-box" id="1093" data-title="미스터힐링" data-idx="1" data-cate-id="55" data-cate-name="카페/아이스크림">
+    <div class="bnf-top">
+     <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635300553816.png" alt="미스터힐링"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">미스터힐링</span>
+     <div class="badge-list">
+      <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+     </div>
+    </div>
+    <div class="bnf-info">
+     <dl class="dl-bnf">
+      <dt>
+       할인형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 할인
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+       </div>
+      </dd>
+     </dl>
+     <dl class="dl-bnf">
+      <dt>
+       적립형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 적립
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+       </div>
+      </dd>
+     </dl>
+    </div><span class="btn-round gra">자세히 보기</span> </a></li>
+  <li><a href="javascript:;" class="benefit-box" id="992" data-title="던킨" data-idx="2" data-cate-id="55" data-cate-name="카페/아이스크림">
+    <div class="bnf-top">
+     <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202203/1648185466264.png" alt="던킨"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">던킨</span>
+     <div class="badge-list">
+      <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+     </div>
+    </div>
+    <div class="bnf-info">
+     <dl class="dl-bnf">
+      <dt>
+       할인형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 할인
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 할인
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+       </div>
+      </dd>
+     </dl>
+     <dl class="dl-bnf">
+      <dt>
+       적립형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 적립
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 적립
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+       </div>
+      </dd>
+     </dl>
+    </div><span class="btn-round gra">자세히 보기</span> </a></li>
+ </ul>
+</div>
+<h2>비슷한 혜택 브랜드</h2>
+<input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+<ul class="benefit-list">
+ <li><a href="javascript:;" class="benefit-box" id="67" data-title="폴 바셋" data-idx="0" data-cate-id="55" data-cate-name="카페/아이스크림">
+   <div class="bnf-top">
+    <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202211/1667888724269.png" alt="폴 바셋"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">폴 바셋</span>
+    <div class="badge-list">
+     <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+    </div>
+   </div>
+   <div class="bnf-info">
+    <dl class="dl-bnf">
+     <dt>
+      할인형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종(사이즈 무관) 구매 시 10% 할인
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+      </div>
+     </dd>
+    </dl>
+    <dl class="dl-bnf">
+     <dt>
+      적립형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피(사이즈 무관) 구매 시 10% 적립
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+      </div>
+     </dd>
+    </dl>
+   </div><span class="btn-round gra">자세히 보기</span> </a></li>
+ <li><a href="javascript:;" class="benefit-box" id="1093" data-title="미스터힐링" data-idx="1" data-cate-id="55" data-cate-name="카페/아이스크림">
+   <div class="bnf-top">
+    <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635300553816.png" alt="미스터힐링"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">미스터힐링</span>
+    <div class="badge-list">
+     <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+    </div>
+   </div>
+   <div class="bnf-info">
+    <dl class="dl-bnf">
+     <dt>
+      할인형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 할인
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+      </div>
+     </dd>
+    </dl>
+    <dl class="dl-bnf">
+     <dt>
+      적립형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 적립
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+      </div>
+     </dd>
+    </dl>
+   </div><span class="btn-round gra">자세히 보기</span> </a></li>
+ <li><a href="javascript:;" class="benefit-box" id="992" data-title="던킨" data-idx="2" data-cate-id="55" data-cate-name="카페/아이스크림">
+   <div class="bnf-top">
+    <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202203/1648185466264.png" alt="던킨"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">던킨</span>
+    <div class="badge-list">
+     <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+    </div>
+   </div>
+   <div class="bnf-info">
+    <dl class="dl-bnf">
+     <dt>
+      할인형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 할인
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 할인
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+      </div>
+     </dd>
+    </dl>
+    <dl class="dl-bnf">
+     <dt>
+      적립형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 적립
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 적립
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+      </div>
+     </dd>
+    </dl>
+   </div><span class="btn-round gra">자세히 보기</span> </a></li>
+</ul>
+<li><a href="javascript:;" class="benefit-box" id="67" data-title="폴 바셋" data-idx="0" data-cate-id="55" data-cate-name="카페/아이스크림">
+  <div class="bnf-top">
+   <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202211/1667888724269.png" alt="폴 바셋"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">폴 바셋</span>
+   <div class="badge-list">
+    <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+   </div>
+  </div>
+  <div class="bnf-info">
+   <dl class="dl-bnf">
+    <dt>
+     할인형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종(사이즈 무관) 구매 시 10% 할인
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+     </div>
+    </dd>
+   </dl>
+   <dl class="dl-bnf">
+    <dt>
+     적립형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피(사이즈 무관) 구매 시 10% 적립
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+     </div>
+    </dd>
+   </dl>
+  </div><span class="btn-round gra">자세히 보기</span> </a></li>
+<a href="javascript:;" class="benefit-box" id="67" data-title="폴 바셋" data-idx="0" data-cate-id="55" data-cate-name="카페/아이스크림">
+ <div class="bnf-top">
+  <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202211/1667888724269.png" alt="폴 바셋"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">폴 바셋</span>
+  <div class="badge-list">
+   <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+  </div>
+ </div>
+ <div class="bnf-info">
+  <dl class="dl-bnf">
+   <dt>
+    할인형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종(사이즈 무관) 구매 시 10% 할인
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+    </div>
+   </dd>
+  </dl>
+  <dl class="dl-bnf">
+   <dt>
+    적립형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피(사이즈 무관) 구매 시 10% 적립
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+    </div>
+   </dd>
+  </dl>
+ </div><span class="btn-round gra">자세히 보기</span> </a>
+<div class="bnf-top">
+ <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202211/1667888724269.png" alt="폴 바셋"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">폴 바셋</span>
+ <div class="badge-list">
+  <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+ </div>
+</div>
+<span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202211/1667888724269.png" alt="폴 바셋"> </span>
+<img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202211/1667888724269.png" alt="폴 바셋">
+<span class="sort">카페/아이스크림</span>
+<span class="brand">폴 바셋</span>
+<div class="badge-list">
+ <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+</div>
+<i class="badge-bg-radius skyBlue">할인</i>
+<i class="badge-bg-radius pink">적립</i>
+<i class="badge-bg-radius skyBlue">사용</i>
+<div class="bnf-info">
+ <dl class="dl-bnf">
+  <dt>
+   할인형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종(사이즈 무관) 구매 시 10% 할인
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+   </div>
+  </dd>
+ </dl>
+ <dl class="dl-bnf">
+  <dt>
+   적립형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피(사이즈 무관) 구매 시 10% 적립
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+   </div>
+  </dd>
+ </dl>
+</div>
+<dl class="dl-bnf">
+ <dt>
+  할인형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종(사이즈 무관) 구매 시 10% 할인
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+  </div>
+ </dd>
+</dl>
+<dt>
+ 할인형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종(사이즈 무관) 구매 시 10% 할인
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종(사이즈 무관) 구매 시 10% 할인
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<dl class="dl-bnf">
+ <dt>
+  적립형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피(사이즈 무관) 구매 시 10% 적립
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+  </div>
+ </dd>
+</dl>
+<dt>
+ 적립형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피(사이즈 무관) 구매 시 10% 적립
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 시그니처 커피(사이즈 무관) 구매 시 10% 적립
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 시그니처 커피 4종 구매 시 포인트 사용가능(100%, 10P 단위)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<i class="badge-circle lite"><span class="blind">L</span></i>
+<span class="blind">L</span>
+<span class="btn-round gra">자세히 보기</span>
+<li><a href="javascript:;" class="benefit-box" id="1093" data-title="미스터힐링" data-idx="1" data-cate-id="55" data-cate-name="카페/아이스크림">
+  <div class="bnf-top">
+   <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635300553816.png" alt="미스터힐링"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">미스터힐링</span>
+   <div class="badge-list">
+    <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+   </div>
+  </div>
+  <div class="bnf-info">
+   <dl class="dl-bnf">
+    <dt>
+     할인형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 할인
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+     </div>
+    </dd>
+   </dl>
+   <dl class="dl-bnf">
+    <dt>
+     적립형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 적립
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+     </div>
+    </dd>
+   </dl>
+  </div><span class="btn-round gra">자세히 보기</span> </a></li>
+<a href="javascript:;" class="benefit-box" id="1093" data-title="미스터힐링" data-idx="1" data-cate-id="55" data-cate-name="카페/아이스크림">
+ <div class="bnf-top">
+  <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635300553816.png" alt="미스터힐링"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">미스터힐링</span>
+  <div class="badge-list">
+   <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+  </div>
+ </div>
+ <div class="bnf-info">
+  <dl class="dl-bnf">
+   <dt>
+    할인형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 할인
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+    </div>
+   </dd>
+  </dl>
+  <dl class="dl-bnf">
+   <dt>
+    적립형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 적립
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+    </div>
+   </dd>
+  </dl>
+ </div><span class="btn-round gra">자세히 보기</span> </a>
+<div class="bnf-top">
+ <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635300553816.png" alt="미스터힐링"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">미스터힐링</span>
+ <div class="badge-list">
+  <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+ </div>
+</div>
+<span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635300553816.png" alt="미스터힐링"> </span>
+<img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635300553816.png" alt="미스터힐링">
+<span class="sort">카페/아이스크림</span>
+<span class="brand">미스터힐링</span>
+<div class="badge-list">
+ <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+</div>
+<i class="badge-bg-radius skyBlue">할인</i>
+<i class="badge-bg-radius pink">적립</i>
+<i class="badge-bg-radius skyBlue">사용</i>
+<div class="bnf-info">
+ <dl class="dl-bnf">
+  <dt>
+   할인형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 할인
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+   </div>
+  </dd>
+ </dl>
+ <dl class="dl-bnf">
+  <dt>
+   적립형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 적립
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+   </div>
+  </dd>
+ </dl>
+</div>
+<dl class="dl-bnf">
+ <dt>
+  할인형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 할인
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+  </div>
+ </dd>
+</dl>
+<dt>
+ 할인형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 할인
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 할인
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<dl class="dl-bnf">
+ <dt>
+  적립형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 적립
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+  </div>
+ </dd>
+</dl>
+<dt>
+ 적립형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 적립
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 8% 적립
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<i class="badge-circle lite"><span class="blind">L</span></i>
+<span class="blind">L</span>
+<span class="btn-round gra">자세히 보기</span>
+<li><a href="javascript:;" class="benefit-box" id="992" data-title="던킨" data-idx="2" data-cate-id="55" data-cate-name="카페/아이스크림">
+  <div class="bnf-top">
+   <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202203/1648185466264.png" alt="던킨"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">던킨</span>
+   <div class="badge-list">
+    <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+   </div>
+  </div>
+  <div class="bnf-info">
+   <dl class="dl-bnf">
+    <dt>
+     할인형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 할인
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 할인
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+     </div>
+    </dd>
+   </dl>
+   <dl class="dl-bnf">
+    <dt>
+     적립형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 적립
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 적립
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+     </div>
+    </dd>
+   </dl>
+  </div><span class="btn-round gra">자세히 보기</span> </a></li>
+<a href="javascript:;" class="benefit-box" id="992" data-title="던킨" data-idx="2" data-cate-id="55" data-cate-name="카페/아이스크림">
+ <div class="bnf-top">
+  <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202203/1648185466264.png" alt="던킨"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">던킨</span>
+  <div class="badge-list">
+   <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+  </div>
+ </div>
+ <div class="bnf-info">
+  <dl class="dl-bnf">
+   <dt>
+    할인형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 할인
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 할인
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+    </div>
+   </dd>
+  </dl>
+  <dl class="dl-bnf">
+   <dt>
+    적립형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 적립
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 적립
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+    </div>
+   </dd>
+  </dl>
+ </div><span class="btn-round gra">자세히 보기</span> </a>
+<div class="bnf-top">
+ <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202203/1648185466264.png" alt="던킨"> </span> <span class="sort">카페/아이스크림</span> <span class="brand">던킨</span>
+ <div class="badge-list">
+  <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+ </div>
+</div>
+<span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202203/1648185466264.png" alt="던킨"> </span>
+<img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202203/1648185466264.png" alt="던킨">
+<span class="sort">카페/아이스크림</span>
+<span class="brand">던킨</span>
+<div class="badge-list">
+ <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+</div>
+<i class="badge-bg-radius skyBlue">할인</i>
+<i class="badge-bg-radius pink">적립</i>
+<i class="badge-bg-radius skyBlue">사용</i>
+<div class="bnf-info">
+ <dl class="dl-bnf">
+  <dt>
+   할인형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 할인
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 할인
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+   </div>
+  </dd>
+ </dl>
+ <dl class="dl-bnf">
+  <dt>
+   적립형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 적립
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 적립
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+   </div>
+  </dd>
+ </dl>
+</div>
+<dl class="dl-bnf">
+ <dt>
+  할인형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 할인
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 할인
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+  </div>
+ </dd>
+</dl>
+<dt>
+ 할인형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 할인
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 할인
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 할인
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 할인
+</div>
+<span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<dl class="dl-bnf">
+ <dt>
+  적립형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 적립
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 적립
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+  </div>
+ </dd>
+</dl>
+<dt>
+ 적립형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 적립
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 적립
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 15% 적립
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 5% 적립
+</div>
+<span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능(100%, 10P 단위)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<i class="badge-circle lite"><span class="blind">L</span></i>
+<span class="blind">L</span>
+<span class="btn-round gra">자세히 보기</span>
+<div id="footer" class="main-footer">
+ <a href="#" class="footer__go-top"><span class="hidden">상단으로 이동</span></a>
+ <div class="main-footer__top">
+  <div class="footer_cont">
+   <!-- 20230411 클래스명 변경 -->
+   <div class="bar-list">
+    <div class="bar-list__item">
+     <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+    </div><!-- 2023-05-23 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+    </div><!-- 2023-05-23 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+    </div><!-- 230515 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+    </div><!-- 230515 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+    </div><!-- 230515 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+    </div><!-- 230515 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+    </div><!-- 230515 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+    </div>
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+    </div><!-- 230515 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+    </div><!-- 230515 수정 -->
+    <div class="bar-list__item">
+     <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+    </div>
+    <div class="bar-list__item">
+     <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+    </div>
+   </div>
+  </div>
+ </div>
+ <div class="main-footer__bottom">
+  <div class="footer_cont">
+   <!-- 20230411 클래스명 변경 -->
+   <div class="logo-list">
+    <div class="logo-list__item">
+     <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+       26년 연속 1위</span></a>
+    </div><!-- 2023-05-30 수정 -->
+    <div class="logo-list__item">
+     <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+       23년 연속 1위</span></a>
+    </div><!-- 20230508 수정 -->
+    <div class="logo-list__item">
+     <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+       25년 연속 1위</span></a>
+    </div><!-- 20230508 수정 -->
+    <div class="logo-list__item">
+     <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+    </div><!-- 20230508 수정 -->
+   </div>
+   <div class="footer__info-box width-auto">
+    <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+    <div class="column-box__item">
+     <div class="column-box__inner">
+      <div class="bar-list bar-list--narrow">
+       <div class="bar-list__item">
+        SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+        <br>
+        (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+       </div>
+       <hr class="bar-list--narrow bar-list--grey">
+       <div class="bar-list__item">
+        <strong>고객센터</strong>
+       </div>
+       <div class="bar-list__item">
+        대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+       </div><!-- 2023-05-23 수정 -->
+       <hr class="bar-list__line">
+       <div class="bar-list__item">
+        인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+       </div><!-- 2023-05-23 수정 -->
+       <div class="bar-list__item">
+        T 멤버십 마켓 : 1599-3377(유료)
+       </div><!-- 2023-05-23 수정 -->
+      </div>
+      <div class="bar-list bar-list--narrow bar-list--grey">
+       <div class="bar-list__item">
+        대표이사/사장 : 유영상
+       </div>
+       <div class="bar-list__item">
+        사업자등록번호 : 104-81-37225
+       </div>
+       <div class="bar-list__item">
+        판매허가번호 : 중구 02923호
+       </div>
+       <div class="bar-list__item">
+        <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+       </div>
+       <hr class="bar-list__line">
+       <div class="bar-list__item">
+        서울특별시 중구 을지로 65
+       </div>
+       <hr class="bar-list__line">
+       <div class="bar-list__item copyright">
+        COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+       </div>
+      </div>
+     </div>
+    </div>
+    <div class="column-box__item column-box__item--right">
+     <div class="column-box__inner">
+      <div class="site-list">
+       <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+       <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+        <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+        <div class="family-list" data-element="commonToggle__layer">
+         <div class="family-list__item">
+          <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+         </div><!-- 2023-05-30 수정 -->
+         <div class="family-list__item">
+          <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+         </div>
+         <div class="family-list__item">
+          <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+         </div>
+         <div class="family-list__item">
+          <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+         </div>
+         <div class="family-list__item">
+          <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+         </div>
+         <div class="family-list__item">
+          <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+         </div>
+         <div class="family-list__item">
+          <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+         </div>
+         <div class="family-list__item">
+          <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+         </div>
+         <div class="family-list__item">
+          <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+         </div>
+        </div>
+       </div>
+      </div>
+      <div class="social-list">
+       <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+ </div>
+</div>
+<a href="#" class="footer__go-top"><span class="hidden">상단으로 이동</span></a>
+<span class="hidden">상단으로 이동</span>
+<div class="main-footer__top">
+ <div class="footer_cont">
+  <!-- 20230411 클래스명 변경 -->
+  <div class="bar-list">
+   <div class="bar-list__item">
+    <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+   </div><!-- 2023-05-23 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+   </div><!-- 2023-05-23 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+   </div><!-- 230515 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+   </div><!-- 230515 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+   </div><!-- 230515 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+   </div><!-- 230515 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+   </div><!-- 230515 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+   </div>
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+   </div><!-- 230515 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+   </div><!-- 230515 수정 -->
+   <div class="bar-list__item">
+    <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+   </div>
+   <div class="bar-list__item">
+    <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="footer_cont">
+ <!-- 20230411 클래스명 변경 -->
+ <div class="bar-list">
+  <div class="bar-list__item">
+   <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+  </div><!-- 2023-05-23 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+  </div><!-- 2023-05-23 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+  </div><!-- 230515 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+  </div><!-- 230515 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+  </div><!-- 230515 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+  </div><!-- 230515 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+  </div><!-- 230515 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+  </div>
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+  </div><!-- 230515 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+  </div><!-- 230515 수정 -->
+  <div class="bar-list__item">
+   <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+  </div>
+  <div class="bar-list__item">
+   <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+  </div>
+ </div>
+</div>
+<div class="bar-list">
+ <div class="bar-list__item">
+  <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+ </div><!-- 2023-05-23 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+ </div><!-- 2023-05-23 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+ </div><!-- 230515 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+ </div><!-- 230515 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+ </div><!-- 230515 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+ </div><!-- 230515 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+ </div><!-- 230515 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+ </div>
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+ </div><!-- 230515 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+ </div><!-- 230515 수정 -->
+ <div class="bar-list__item">
+  <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+ </div>
+ <div class="bar-list__item">
+  <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+ </div>
+</div>
+<div class="bar-list__item">
+ <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+</div>
+<a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+<div class="bar-list__item">
+ <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+</div>
+<a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+<strong>개인정보 처리방침</strong>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+<strong>멤버십 통합 개인정보처리방침</strong>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+<strong>T 멤버십 전자상거래 개인정보 처리방침</strong>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+<strong>위치기반서비스 이용약관</strong>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+<div class="bar-list__item">
+ <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+</div>
+<a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+<strong>분쟁처리절차</strong>
+<div class="bar-list__item">
+ <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+</div>
+<a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+<strong>T 멤버십 제휴 제안</strong>
+<div class="main-footer__bottom">
+ <div class="footer_cont">
+  <!-- 20230411 클래스명 변경 -->
+  <div class="logo-list">
+   <div class="logo-list__item">
+    <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+      26년 연속 1위</span></a>
+   </div><!-- 2023-05-30 수정 -->
+   <div class="logo-list__item">
+    <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+      23년 연속 1위</span></a>
+   </div><!-- 20230508 수정 -->
+   <div class="logo-list__item">
+    <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+      25년 연속 1위</span></a>
+   </div><!-- 20230508 수정 -->
+   <div class="logo-list__item">
+    <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+   </div><!-- 20230508 수정 -->
+  </div>
+  <div class="footer__info-box width-auto">
+   <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+   <div class="column-box__item">
+    <div class="column-box__inner">
+     <div class="bar-list bar-list--narrow">
+      <div class="bar-list__item">
+       SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+       <br>
+       (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+      </div>
+      <hr class="bar-list--narrow bar-list--grey">
+      <div class="bar-list__item">
+       <strong>고객센터</strong>
+      </div>
+      <div class="bar-list__item">
+       대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+      </div><!-- 2023-05-23 수정 -->
+      <hr class="bar-list__line">
+      <div class="bar-list__item">
+       인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+      </div><!-- 2023-05-23 수정 -->
+      <div class="bar-list__item">
+       T 멤버십 마켓 : 1599-3377(유료)
+      </div><!-- 2023-05-23 수정 -->
+     </div>
+     <div class="bar-list bar-list--narrow bar-list--grey">
+      <div class="bar-list__item">
+       대표이사/사장 : 유영상
+      </div>
+      <div class="bar-list__item">
+       사업자등록번호 : 104-81-37225
+      </div>
+      <div class="bar-list__item">
+       판매허가번호 : 중구 02923호
+      </div>
+      <div class="bar-list__item">
+       <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+      </div>
+      <hr class="bar-list__line">
+      <div class="bar-list__item">
+       서울특별시 중구 을지로 65
+      </div>
+      <hr class="bar-list__line">
+      <div class="bar-list__item copyright">
+       COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+      </div>
+     </div>
+    </div>
+   </div>
+   <div class="column-box__item column-box__item--right">
+    <div class="column-box__inner">
+     <div class="site-list">
+      <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+      <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+       <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+       <div class="family-list" data-element="commonToggle__layer">
+        <div class="family-list__item">
+         <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+        </div><!-- 2023-05-30 수정 -->
+        <div class="family-list__item">
+         <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+        </div>
+        <div class="family-list__item">
+         <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+        </div>
+        <div class="family-list__item">
+         <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+        </div>
+        <div class="family-list__item">
+         <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+        </div>
+        <div class="family-list__item">
+         <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+        </div>
+        <div class="family-list__item">
+         <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+        </div>
+        <div class="family-list__item">
+         <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+        </div>
+        <div class="family-list__item">
+         <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+        </div>
+       </div>
+      </div>
+     </div>
+     <div class="social-list">
+      <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+     </div>
+    </div>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="footer_cont">
+ <!-- 20230411 클래스명 변경 -->
+ <div class="logo-list">
+  <div class="logo-list__item">
+   <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+     26년 연속 1위</span></a>
+  </div><!-- 2023-05-30 수정 -->
+  <div class="logo-list__item">
+   <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+     23년 연속 1위</span></a>
+  </div><!-- 20230508 수정 -->
+  <div class="logo-list__item">
+   <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+     25년 연속 1위</span></a>
+  </div><!-- 20230508 수정 -->
+  <div class="logo-list__item">
+   <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+  </div><!-- 20230508 수정 -->
+ </div>
+ <div class="footer__info-box width-auto">
+  <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+  <div class="column-box__item">
+   <div class="column-box__inner">
+    <div class="bar-list bar-list--narrow">
+     <div class="bar-list__item">
+      SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+      <br>
+      (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+     </div>
+     <hr class="bar-list--narrow bar-list--grey">
+     <div class="bar-list__item">
+      <strong>고객센터</strong>
+     </div>
+     <div class="bar-list__item">
+      대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+     </div><!-- 2023-05-23 수정 -->
+     <hr class="bar-list__line">
+     <div class="bar-list__item">
+      인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+     </div><!-- 2023-05-23 수정 -->
+     <div class="bar-list__item">
+      T 멤버십 마켓 : 1599-3377(유료)
+     </div><!-- 2023-05-23 수정 -->
+    </div>
+    <div class="bar-list bar-list--narrow bar-list--grey">
+     <div class="bar-list__item">
+      대표이사/사장 : 유영상
+     </div>
+     <div class="bar-list__item">
+      사업자등록번호 : 104-81-37225
+     </div>
+     <div class="bar-list__item">
+      판매허가번호 : 중구 02923호
+     </div>
+     <div class="bar-list__item">
+      <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+     </div>
+     <hr class="bar-list__line">
+     <div class="bar-list__item">
+      서울특별시 중구 을지로 65
+     </div>
+     <hr class="bar-list__line">
+     <div class="bar-list__item copyright">
+      COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+     </div>
+    </div>
+   </div>
+  </div>
+  <div class="column-box__item column-box__item--right">
+   <div class="column-box__inner">
+    <div class="site-list">
+     <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+     <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+      <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+      <div class="family-list" data-element="commonToggle__layer">
+       <div class="family-list__item">
+        <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+       </div><!-- 2023-05-30 수정 -->
+       <div class="family-list__item">
+        <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+       </div>
+       <div class="family-list__item">
+        <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+       </div>
+       <div class="family-list__item">
+        <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+       </div>
+       <div class="family-list__item">
+        <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+       </div>
+       <div class="family-list__item">
+        <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+       </div>
+       <div class="family-list__item">
+        <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+       </div>
+       <div class="family-list__item">
+        <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+       </div>
+       <div class="family-list__item">
+        <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+       </div>
+      </div>
+     </div>
+    </div>
+    <div class="social-list">
+     <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+    </div>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="logo-list">
+ <div class="logo-list__item">
+  <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+    26년 연속 1위</span></a>
+ </div><!-- 2023-05-30 수정 -->
+ <div class="logo-list__item">
+  <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+    23년 연속 1위</span></a>
+ </div><!-- 20230508 수정 -->
+ <div class="logo-list__item">
+  <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+    25년 연속 1위</span></a>
+ </div><!-- 20230508 수정 -->
+ <div class="logo-list__item">
+  <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+ </div><!-- 20230508 수정 -->
+</div>
+<div class="logo-list__item">
+ <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+   26년 연속 1위</span></a>
+</div>
+<a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+  26년 연속 1위</span></a>
+<span>국가고객만족도<br>
+ 26년 연속 1위</span>
+<br>
+<div class="logo-list__item">
+ <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+   23년 연속 1위</span></a>
+</div>
+<a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+  23년 연속 1위</span></a>
+<span>한국서비스품질지수<br>
+ 23년 연속 1위</span>
+<br>
+<div class="logo-list__item">
+ <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+   25년 연속 1위</span></a>
+</div>
+<a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+  25년 연속 1위</span></a>
+<span>한국산업고객만족도<br>
+ 25년 연속 1위</span>
+<br>
+<div class="logo-list__item">
+ <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+</div>
+<a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+<span>와이즈유저</span>
+<div class="footer__info-box width-auto">
+ <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+ <div class="column-box__item">
+  <div class="column-box__inner">
+   <div class="bar-list bar-list--narrow">
+    <div class="bar-list__item">
+     SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+     <br>
+     (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+    </div>
+    <hr class="bar-list--narrow bar-list--grey">
+    <div class="bar-list__item">
+     <strong>고객센터</strong>
+    </div>
+    <div class="bar-list__item">
+     대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+    </div><!-- 2023-05-23 수정 -->
+    <hr class="bar-list__line">
+    <div class="bar-list__item">
+     인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+    </div><!-- 2023-05-23 수정 -->
+    <div class="bar-list__item">
+     T 멤버십 마켓 : 1599-3377(유료)
+    </div><!-- 2023-05-23 수정 -->
+   </div>
+   <div class="bar-list bar-list--narrow bar-list--grey">
+    <div class="bar-list__item">
+     대표이사/사장 : 유영상
+    </div>
+    <div class="bar-list__item">
+     사업자등록번호 : 104-81-37225
+    </div>
+    <div class="bar-list__item">
+     판매허가번호 : 중구 02923호
+    </div>
+    <div class="bar-list__item">
+     <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+    </div>
+    <hr class="bar-list__line">
+    <div class="bar-list__item">
+     서울특별시 중구 을지로 65
+    </div>
+    <hr class="bar-list__line">
+    <div class="bar-list__item copyright">
+     COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+    </div>
+   </div>
+  </div>
+ </div>
+ <div class="column-box__item column-box__item--right">
+  <div class="column-box__inner">
+   <div class="site-list">
+    <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+    <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+     <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+     <div class="family-list" data-element="commonToggle__layer">
+      <div class="family-list__item">
+       <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+      </div><!-- 2023-05-30 수정 -->
+      <div class="family-list__item">
+       <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+      </div>
+      <div class="family-list__item">
+       <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+      </div>
+      <div class="family-list__item">
+       <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+      </div>
+      <div class="family-list__item">
+       <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+      </div>
+      <div class="family-list__item">
+       <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+      </div>
+      <div class="family-list__item">
+       <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+      </div>
+      <div class="family-list__item">
+       <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+      </div>
+      <div class="family-list__item">
+       <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+      </div>
+     </div>
+    </div>
+   </div>
+   <div class="social-list">
+    <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="column-box__item">
+ <div class="column-box__inner">
+  <div class="bar-list bar-list--narrow">
+   <div class="bar-list__item">
+    SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+    <br>
+    (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+   </div>
+   <hr class="bar-list--narrow bar-list--grey">
+   <div class="bar-list__item">
+    <strong>고객센터</strong>
+   </div>
+   <div class="bar-list__item">
+    대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+   </div><!-- 2023-05-23 수정 -->
+   <hr class="bar-list__line">
+   <div class="bar-list__item">
+    인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+   </div><!-- 2023-05-23 수정 -->
+   <div class="bar-list__item">
+    T 멤버십 마켓 : 1599-3377(유료)
+   </div><!-- 2023-05-23 수정 -->
+  </div>
+  <div class="bar-list bar-list--narrow bar-list--grey">
+   <div class="bar-list__item">
+    대표이사/사장 : 유영상
+   </div>
+   <div class="bar-list__item">
+    사업자등록번호 : 104-81-37225
+   </div>
+   <div class="bar-list__item">
+    판매허가번호 : 중구 02923호
+   </div>
+   <div class="bar-list__item">
+    <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+   </div>
+   <hr class="bar-list__line">
+   <div class="bar-list__item">
+    서울특별시 중구 을지로 65
+   </div>
+   <hr class="bar-list__line">
+   <div class="bar-list__item copyright">
+    COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+   </div>
+  </div>
+ </div>
+</div>
+<div class="column-box__inner">
+ <div class="bar-list bar-list--narrow">
+  <div class="bar-list__item">
+   SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+   <br>
+   (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+  </div>
+  <hr class="bar-list--narrow bar-list--grey">
+  <div class="bar-list__item">
+   <strong>고객센터</strong>
+  </div>
+  <div class="bar-list__item">
+   대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+  </div><!-- 2023-05-23 수정 -->
+  <hr class="bar-list__line">
+  <div class="bar-list__item">
+   인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+  </div><!-- 2023-05-23 수정 -->
+  <div class="bar-list__item">
+   T 멤버십 마켓 : 1599-3377(유료)
+  </div><!-- 2023-05-23 수정 -->
+ </div>
+ <div class="bar-list bar-list--narrow bar-list--grey">
+  <div class="bar-list__item">
+   대표이사/사장 : 유영상
+  </div>
+  <div class="bar-list__item">
+   사업자등록번호 : 104-81-37225
+  </div>
+  <div class="bar-list__item">
+   판매허가번호 : 중구 02923호
+  </div>
+  <div class="bar-list__item">
+   <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+  </div>
+  <hr class="bar-list__line">
+  <div class="bar-list__item">
+   서울특별시 중구 을지로 65
+  </div>
+  <hr class="bar-list__line">
+  <div class="bar-list__item copyright">
+   COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+  </div>
+ </div>
+</div>
+<div class="bar-list bar-list--narrow">
+ <div class="bar-list__item">
+  SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+  <br>
+  (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+ </div>
+ <hr class="bar-list--narrow bar-list--grey">
+ <div class="bar-list__item">
+  <strong>고객센터</strong>
+ </div>
+ <div class="bar-list__item">
+  대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+ </div><!-- 2023-05-23 수정 -->
+ <hr class="bar-list__line">
+ <div class="bar-list__item">
+  인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+ </div><!-- 2023-05-23 수정 -->
+ <div class="bar-list__item">
+  T 멤버십 마켓 : 1599-3377(유료)
+ </div><!-- 2023-05-23 수정 -->
+</div>
+<div class="bar-list__item">
+ SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+ <br>
+ (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+</div>
+<br>
+<hr class="bar-list--narrow bar-list--grey">
+<div class="bar-list__item">
+ <strong>고객센터</strong>
+</div>
+<strong>고객센터</strong>
+<div class="bar-list__item">
+ 대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+</div>
+<hr class="bar-list__line">
+<div class="bar-list__item">
+ 인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+</div>
+<div class="bar-list__item">
+ T 멤버십 마켓 : 1599-3377(유료)
+</div>
+<div class="bar-list bar-list--narrow bar-list--grey">
+ <div class="bar-list__item">
+  대표이사/사장 : 유영상
+ </div>
+ <div class="bar-list__item">
+  사업자등록번호 : 104-81-37225
+ </div>
+ <div class="bar-list__item">
+  판매허가번호 : 중구 02923호
+ </div>
+ <div class="bar-list__item">
+  <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+ </div>
+ <hr class="bar-list__line">
+ <div class="bar-list__item">
+  서울특별시 중구 을지로 65
+ </div>
+ <hr class="bar-list__line">
+ <div class="bar-list__item copyright">
+  COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+ </div>
+</div>
+<div class="bar-list__item">
+ 대표이사/사장 : 유영상
+</div>
+<div class="bar-list__item">
+ 사업자등록번호 : 104-81-37225
+</div>
+<div class="bar-list__item">
+ 판매허가번호 : 중구 02923호
+</div>
+<div class="bar-list__item">
+ <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+</div>
+<a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+<hr class="bar-list__line">
+<div class="bar-list__item">
+ 서울특별시 중구 을지로 65
+</div>
+<hr class="bar-list__line">
+<div class="bar-list__item copyright">
+ COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+</div>
+<div class="column-box__item column-box__item--right">
+ <div class="column-box__inner">
+  <div class="site-list">
+   <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+   <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+    <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+    <div class="family-list" data-element="commonToggle__layer">
+     <div class="family-list__item">
+      <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+     </div><!-- 2023-05-30 수정 -->
+     <div class="family-list__item">
+      <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+     </div>
+     <div class="family-list__item">
+      <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+     </div>
+     <div class="family-list__item">
+      <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+     </div>
+     <div class="family-list__item">
+      <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+     </div>
+     <div class="family-list__item">
+      <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+     </div>
+     <div class="family-list__item">
+      <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+     </div>
+     <div class="family-list__item">
+      <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+     </div>
+     <div class="family-list__item">
+      <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+     </div>
+    </div>
+   </div>
+  </div>
+  <div class="social-list">
+   <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+  </div>
+ </div>
+</div>
+<div class="column-box__inner">
+ <div class="site-list">
+  <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+  <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+   <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+   <div class="family-list" data-element="commonToggle__layer">
+    <div class="family-list__item">
+     <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+    </div><!-- 2023-05-30 수정 -->
+    <div class="family-list__item">
+     <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+    </div>
+    <div class="family-list__item">
+     <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+    </div>
+    <div class="family-list__item">
+     <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+    </div>
+    <div class="family-list__item">
+     <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+    </div>
+    <div class="family-list__item">
+     <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+    </div>
+    <div class="family-list__item">
+     <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+    </div>
+    <div class="family-list__item">
+     <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+    </div>
+    <div class="family-list__item">
+     <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+    </div>
+   </div>
+  </div>
+ </div>
+ <div class="social-list">
+  <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+ </div>
+</div>
+<div class="site-list">
+ <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+ <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+  <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+  <div class="family-list" data-element="commonToggle__layer">
+   <div class="family-list__item">
+    <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+   </div><!-- 2023-05-30 수정 -->
+   <div class="family-list__item">
+    <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+   </div>
+   <div class="family-list__item">
+    <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+   </div>
+   <div class="family-list__item">
+    <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+   </div>
+   <div class="family-list__item">
+    <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+   </div>
+   <div class="family-list__item">
+    <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+   </div>
+   <div class="family-list__item">
+    <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+   </div>
+   <div class="family-list__item">
+    <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+   </div>
+   <div class="family-list__item">
+    <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+   </div>
+  </div>
+ </div>
+</div>
+<a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+<span>ENG</span>
+<div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+ <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+ <div class="family-list" data-element="commonToggle__layer">
+  <div class="family-list__item">
+   <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+  </div><!-- 2023-05-30 수정 -->
+  <div class="family-list__item">
+   <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+  </div>
+  <div class="family-list__item">
+   <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+  </div>
+  <div class="family-list__item">
+   <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+  </div>
+  <div class="family-list__item">
+   <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+  </div>
+  <div class="family-list__item">
+   <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+  </div>
+  <div class="family-list__item">
+   <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+  </div>
+  <div class="family-list__item">
+   <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+  </div>
+  <div class="family-list__item">
+   <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+  </div>
+ </div>
+</div>
+<button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+<div class="family-list" data-element="commonToggle__layer">
+ <div class="family-list__item">
+  <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+ </div><!-- 2023-05-30 수정 -->
+ <div class="family-list__item">
+  <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+ </div>
+ <div class="family-list__item">
+  <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+ </div>
+ <div class="family-list__item">
+  <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+ </div>
+ <div class="family-list__item">
+  <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+ </div>
+ <div class="family-list__item">
+  <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+ </div>
+ <div class="family-list__item">
+  <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+ </div>
+ <div class="family-list__item">
+  <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+ </div>
+ <div class="family-list__item">
+  <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+ </div>
+</div>
+<div class="family-list__item">
+ <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+</div>
+<a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+<div class="family-list__item">
+ <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+</div>
+<a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+<div class="family-list__item">
+ <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+</div>
+<a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+<div class="family-list__item">
+ <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+</div>
+<a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+<div class="family-list__item">
+ <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+</div>
+<a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+<div class="family-list__item">
+ <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+</div>
+<a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+<div class="family-list__item">
+ <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+</div>
+<a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+<div class="family-list__item">
+ <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+</div>
+<a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+<div class="family-list__item">
+ <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+</div>
+<a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+<div class="social-list">
+ <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+</div>
+<a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a>
+<span>twitter</span>
+<a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a>
+<span>Facebook</span>
+<a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a>
+<span>Blog</span>
+<a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a>
+<span>YouTube</span>
+<a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a>
+<span>Kakao Story</span>
+<a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+<span>Instagram</span>
+<script type="text/javascript" src="/js/benefitbrand/MPW_D001_P03-f38ad4ae8f7e63be2335a3a34ed7a5af.js"></script>
+<div class="toast01" data-toast="toastContainer" data-y="bottom" data-duration="800" data-pos="20" data-timer="3000">
+ <span id="toastContainer"></span>
+</div>
+<span id="toastContainer"></span>
+<div class="loadingbar-area"></div>

--- a/docs/MembershipTest/SKTTest2.html
+++ b/docs/MembershipTest/SKTTest2.html
@@ -1,0 +1,7994 @@
+<!doctype html>
+<html lang="ko">
+ <head>
+  <title>T 멤버십</title>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Type" content="text/html">
+  <meta http-equiv="Content-Script-Type" content="text/javascript">
+  <meta http-equiv="Content-Style-Type" content="text/css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, viewport-fit=cover">
+  <meta http-equiv="X-UA-compatible" content="IE=edge,chrome=1">
+  <link rel="shortcut icon" href="https://cdn.sktmembership.co.kr/mps.pc/favicon.ico" type="image/x-icon">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/poc/inc/css/footer.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/jquery-ui.min.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/swiper.min.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/common.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/style.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/wait.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/benefit.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/re_gnb.css">
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-3.4.1.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-ui.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/swiper.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/common.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/promise-polyfill.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/common/jsrender.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/axios.min.js"></script>
+  <script>
+        var CDN_PATH = "https:\/\/cdn.sktmembership.co.kr\/mps.pc";
+        var ENV = "prd";
+        var IS_LOGIN = false;
+        var IS_MBR_CARD = false;
+    </script>
+  <script type="text/javascript" src="/js/common-4c70bc9059822c175d8f8e59ac010eef.js"></script>
+  <script type="text/javascript" src="/js/netfunnel-194808761f66576464c07f70ba55a195.js"></script><!--     <link rel="stylesheet" type="text/css" th:href="@{${_config.url('/poc/gnb/inc/css/gnb.css')}}"> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/js/jquery.gnb.js')}}"></script> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/js/gnb.js')}}"></script> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/cmn/gnb_cmn.js')}}"></script> --> <!-- 	<script type="text/javascript" th:src="@{'/poc/gnb/inc/cmn/re_gnb.js'}"></script> -->
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/js/re_gnb.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/cmn/common_url_new.js"></script>
+  <script src="https://xtr.tos.sktelecom.com/js/xtractor_script.js"></script>
+ </head>
+ <body>
+  <div class="accessbility">
+   <a href="#content">본문 바로가기</a>
+  </div>
+  <div class="wrap" id="wrap">
+   <!--<div id="header"></div>-->
+   <div id="header" class="main-header">
+    <input id="envUrl" hidden value="https://www.tworld.co.kr">
+    <div class="main-header__inner">
+     <!-- header 상단 기본 -->
+     <div class="main-header__top">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__logo">
+        <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+       </div>
+       <div class="main-header__util-item" id="gnb_login">
+        <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+        <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+       </div>
+       <div class="main-header__family-site family-list">
+        <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+       </div>
+      </div>
+     </div><!-- // header 상단 기본 --> <!-- GNB 기본 -->
+     <div class="main-header__bottom">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu gnb">
+        <!-- 활성화된 메뉴의 a 태그에 is-active -->
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+        </div>
+       </div>
+       <div class="main-header__util header-util">
+        <div class="header-util__item">
+         <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB 기본 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T membership main --> <!-- 혜택 브랜드 --> <!-- 20230414 2depth 삭제 --> <!-- GNB 서브페이지 (상품서비스) -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+        </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+       </div>
+      </div>
+     </div><!-- // GNB 서브페이지 (my) --> <!-- //20230414 2depth 삭제 --> <!-- //혜택 브랜드 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 혜택 프로그램 --> <!-- GNB Family menu -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB Family menu --> <!-- //혜택 프로그램 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 나의 T 멤버십 --> <!-- GNB Family menu -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB Family menu --> <!-- //나의 T 멤버십 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T 멤버십 안내 --> <!-- GNB Family menu -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB Family menu --> <!-- //T 멤버십 안내 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> -->
+    </div>
+   </div>
+   <div class="container">
+    <div id="content">
+     <div class="inr-wrap">
+      <div class="title-area">
+       <h1>파리바게뜨</h1><input type="hidden" name="brandId" id="brandId" value="1053"> <input type="hidden" name="brandName" id="brandName" value="파리바게뜨">
+      </div><!-- 브랜드 상단 영역 -->
+      <div class="brnad-info-top">
+       <div class="bit-left">
+        <p class="tit">대한민국 베이커리 문화를 선도하는 건강한 베이커리</p>
+        <div class="badge-list">
+         <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+        </div>
+       </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635235481847.png" alt="파리바게뜨"> </span>
+      </div><!-- //브랜드 상단 영역 --> <!-- 브랜드 선택 영역 -->
+      <div class="brand-sel-box">
+       <div class="fc-select">
+        <span>고객님이 선택하신 브랜드는</span>
+        <div class="dropdown" data-selectbox>
+         <a href="javascript:;" data-set-button> <span></span></a>
+         <div data-set-list>
+          <ul id="sel-ul">
+           <!-- 선택된 값에 'data-selected' 추가 -->
+           <li id="53" data-selected="data-selected"><a>베이커리</a></li>
+           <li id="54"><a>외식</a></li>
+           <li id="55"><a>카페/아이스크림</a></li>
+           <li id="56"><a>피자/치킨</a></li>
+           <li id="48"><a>금융/통신</a></li>
+           <li id="112"><a>렌탈</a></li>
+           <li id="116"><a>반려동물</a></li>
+           <li id="49"><a>생활/교통</a></li>
+           <li id="50"><a>쇼핑몰</a></li>
+           <li id="51"><a>패션/뷰티</a></li>
+           <li id="52"><a>편의점</a></li>
+           <li id="57"><a>교육</a></li>
+           <li id="109"><a>액티비티</a></li>
+           <li id="59"><a>여행</a></li>
+           <li id="60"><a>영화/공연/전시</a></li>
+           <li id="61"><a>콘텐츠</a></li>
+           <li id="110"><a>테마파크</a></li>
+          </ul>
+         </div>
+        </div>
+        <div class="dropdown" data-selectbox>
+         <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+         <div id="smallList" data-set-list>
+          <ul id="sel-list">
+           <li id="1053" data-selected="data-selected"><a>파리바게뜨</a></li>
+           <li id="1084"><a>뚜레쥬르</a></li>
+           <li id="1121"><a>파리크라상</a></li>
+           <li id="1151"><a>빌리엔젤</a></li>
+           <li id="1097"><a>열린베이커리</a></li>
+          </ul>
+         </div>
+        </div><span>입니다.</span>
+       </div>
+      </div><!-- //브랜드 선택 영역 --> <!-- 브랜드 상세 혜택 소개 영역 -->
+      <div class="brand-detail">
+       <div class="bd-top">
+        <div class="cate">
+         <span>EAT </span> <span>베이커리</span> <input type="hidden" name="categoryMid" id="categoryMid" value="53"> <input type="hidden" name="categoryMname" id="categoryMname" value="베이커리">
+        </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">127094</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="127094"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+       </div>
+       <div class="detail-list">
+        <dl>
+         <dt>
+          혜택
+         </dt>
+         <dd>
+          <dl class="dl-bnf">
+           <dt>
+            할인형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+          <dl class="dl-bnf">
+           <dt>
+            적립형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+         </dd>
+        </dl>
+        <dl>
+         <dt>
+          유의사항
+         </dt>
+         <dd>
+          <div class="notice">
+           <div class="explain-area pd-no">
+            <ul class="list-dot">
+             <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+             <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+             <li>횟수 제한 : 1일 1회 결제금액 1천 원 이상 시 할인 또는 적립 가능</li>
+             <li>최대 할인 가능 : 플라스틱 카드 이용 시 일 최대 10,000원 할인</li>
+             <li>최대 할인 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000원, SILVER 10,000원 할인</li>
+             <li>최대 적립 가능 : 플라스틱 카드 이용 시 일 최대 10,000P 적립</li>
+             <li>최대 적립 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000P, SILVER 10,000P 적립</li>
+             <li>결제 전 직원에게 T 멤버십 카드 제시</li>
+             <li>타 적립 및 쿠폰 동시 적용 불가</li>
+             <li>제외 매장 : 일부 점포(휴게소, 역사, 인샵, 특수매장 등) 제외 됩니다.</li>
+             <li>적립된 포인트는 ‘적립 예정’ 포인트로 표시되며, 결제일 1일 이후부터 사용 가능 포인트로 전환됩니다.</li>
+            </ul>
+           </div>
+          </div>
+         </dd>
+        </dl>
+        <dl>
+         <dt>
+          문의 및 상담
+         </dt>
+         <dd>
+          <ul class="list-dash">
+           <li>TEL : 080-731-2027</li>
+           <li>HOME : <a href="javascript:goHomePage('https://www.paris.co.kr/')">https://www.paris.co.kr/</a></li>
+          </ul>
+         </dd>
+        </dl>
+       </div>
+      </div>
+     </div><!-- //브랜드 상세 혜택 소개 영역 --> <!-- 비슷한 혜택 브랜드 추천 영역 -->
+     <div class="similar-area">
+      <div class="inr-wrap">
+       <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+       <ul class="benefit-list">
+        <li><a href="javascript:;" class="benefit-box" id="1121" data-title="파리크라상" data-idx="0" data-cate-id="53" data-cate-name="베이커리">
+          <div class="bnf-top">
+           <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635236220043.png" alt="파리크라상"> </span> <span class="sort">베이커리</span> <span class="brand">파리크라상</span>
+           <div class="badge-list">
+            <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+           </div>
+          </div>
+          <div class="bnf-info">
+           <dl class="dl-bnf">
+            <dt>
+             할인형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+           <dl class="dl-bnf">
+            <dt>
+             적립형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+          </div><span class="btn-round gra">자세히 보기</span> </a></li>
+        <li><a href="javascript:;" class="benefit-box" id="1151" data-title="빌리엔젤" data-idx="1" data-cate-id="53" data-cate-name="베이커리">
+          <div class="bnf-top">
+           <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202209/1663893303634.png" alt="빌리엔젤"> </span> <span class="sort">베이커리</span> <span class="brand">빌리엔젤</span>
+           <div class="badge-list">
+            <i class="badge-bg-radius skyBlue">할인</i>
+           </div>
+          </div>
+          <div class="bnf-info">
+           <dl class="dl-bnf">
+            <dt>
+             할인형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+             </div>
+            </dd>
+           </dl>
+           <dl class="dl-bnf">
+            <dt>
+             적립형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+             </div>
+            </dd>
+           </dl>
+          </div><span class="btn-round gra">자세히 보기</span> </a></li>
+        <li><a href="javascript:;" class="benefit-box" id="1084" data-title="뚜레쥬르" data-idx="2" data-cate-id="53" data-cate-name="베이커리">
+          <div class="bnf-top">
+           <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635148435539.png" alt="뚜레쥬르"> </span> <span class="sort">베이커리</span> <span class="brand">뚜레쥬르</span>
+           <div class="badge-list">
+            <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+           </div>
+          </div>
+          <div class="bnf-info">
+           <dl class="dl-bnf">
+            <dt>
+             할인형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150원 할인
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50원 할인
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+           <dl class="dl-bnf">
+            <dt>
+             적립형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150P 적립
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50P 적립
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+          </div><span class="btn-round gra">자세히 보기</span> </a></li>
+       </ul>
+      </div>
+     </div><!-- //비슷한 혜택 브랜드 추천 영역 -->
+    </div>
+   </div><!--         <div id="footer"></div> -->
+   <div id="footer" class="main-footer">
+    <a href="#" class="footer__go-top"><span class="hidden">상단으로 이동</span></a>
+    <div class="main-footer__top">
+     <div class="footer_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="bar-list">
+       <div class="bar-list__item">
+        <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+       </div><!-- 2023-05-23 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+       </div><!-- 2023-05-23 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+       </div>
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+       </div>
+       <div class="bar-list__item">
+        <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+       </div>
+      </div>
+     </div>
+    </div>
+    <div class="main-footer__bottom">
+     <div class="footer_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="logo-list">
+       <div class="logo-list__item">
+        <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+          26년 연속 1위</span></a>
+       </div><!-- 2023-05-30 수정 -->
+       <div class="logo-list__item">
+        <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+          23년 연속 1위</span></a>
+       </div><!-- 20230508 수정 -->
+       <div class="logo-list__item">
+        <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+          25년 연속 1위</span></a>
+       </div><!-- 20230508 수정 -->
+       <div class="logo-list__item">
+        <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+       </div><!-- 20230508 수정 -->
+      </div>
+      <div class="footer__info-box width-auto">
+       <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+       <div class="column-box__item">
+        <div class="column-box__inner">
+         <div class="bar-list bar-list--narrow">
+          <div class="bar-list__item">
+           SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+           <br>
+           (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+          </div>
+          <hr class="bar-list--narrow bar-list--grey">
+          <div class="bar-list__item">
+           <strong>고객센터</strong>
+          </div>
+          <div class="bar-list__item">
+           대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+          </div><!-- 2023-05-23 수정 -->
+          <hr class="bar-list__line">
+          <div class="bar-list__item">
+           인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+          </div><!-- 2023-05-23 수정 -->
+          <div class="bar-list__item">
+           T 멤버십 마켓 : 1599-3377(유료)
+          </div><!-- 2023-05-23 수정 -->
+         </div>
+         <div class="bar-list bar-list--narrow bar-list--grey">
+          <div class="bar-list__item">
+           대표이사/사장 : 유영상
+          </div>
+          <div class="bar-list__item">
+           사업자등록번호 : 104-81-37225
+          </div>
+          <div class="bar-list__item">
+           판매허가번호 : 중구 02923호
+          </div>
+          <div class="bar-list__item">
+           <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+          </div>
+          <hr class="bar-list__line">
+          <div class="bar-list__item">
+           서울특별시 중구 을지로 65
+          </div>
+          <hr class="bar-list__line">
+          <div class="bar-list__item copyright">
+           COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+          </div>
+         </div>
+        </div>
+       </div>
+       <div class="column-box__item column-box__item--right">
+        <div class="column-box__inner">
+         <div class="site-list">
+          <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+          <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+           <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+           <div class="family-list" data-element="commonToggle__layer">
+            <div class="family-list__item">
+             <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+            </div><!-- 2023-05-30 수정 -->
+            <div class="family-list__item">
+             <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+            </div>
+            <div class="family-list__item">
+             <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+            </div>
+            <div class="family-list__item">
+             <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+            </div>
+           </div>
+          </div>
+         </div>
+         <div class="social-list">
+          <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+         </div>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+   <script type="text/javascript" src="/js/benefitbrand/MPW_D001_P03-f38ad4ae8f7e63be2335a3a34ed7a5af.js"></script>
+  </div>
+  <div class="toast01" data-toast="toastContainer" data-y="bottom" data-duration="800" data-pos="20" data-timer="3000">
+   <span id="toastContainer"></span>
+  </div>
+  <div class="loadingbar-area"></div>
+ </body>
+</html>
+<html lang="ko">
+ <head>
+  <title>T 멤버십</title>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Type" content="text/html">
+  <meta http-equiv="Content-Script-Type" content="text/javascript">
+  <meta http-equiv="Content-Style-Type" content="text/css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, viewport-fit=cover">
+  <meta http-equiv="X-UA-compatible" content="IE=edge,chrome=1">
+  <link rel="shortcut icon" href="https://cdn.sktmembership.co.kr/mps.pc/favicon.ico" type="image/x-icon">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/poc/inc/css/footer.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/jquery-ui.min.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/swiper.min.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/common.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/style.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/wait.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/benefit.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/re_gnb.css">
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-3.4.1.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-ui.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/swiper.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/common.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/promise-polyfill.min.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/common/jsrender.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/axios.min.js"></script>
+  <script>
+        var CDN_PATH = "https:\/\/cdn.sktmembership.co.kr\/mps.pc";
+        var ENV = "prd";
+        var IS_LOGIN = false;
+        var IS_MBR_CARD = false;
+    </script>
+  <script type="text/javascript" src="/js/common-4c70bc9059822c175d8f8e59ac010eef.js"></script>
+  <script type="text/javascript" src="/js/netfunnel-194808761f66576464c07f70ba55a195.js"></script><!--     <link rel="stylesheet" type="text/css" th:href="@{${_config.url('/poc/gnb/inc/css/gnb.css')}}"> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/js/jquery.gnb.js')}}"></script> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/js/gnb.js')}}"></script> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/cmn/gnb_cmn.js')}}"></script> --> <!-- 	<script type="text/javascript" th:src="@{'/poc/gnb/inc/cmn/re_gnb.js'}"></script> -->
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/js/re_gnb.js"></script>
+  <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/cmn/common_url_new.js"></script>
+  <script src="https://xtr.tos.sktelecom.com/js/xtractor_script.js"></script>
+ </head>
+ <body>
+  <div class="accessbility">
+   <a href="#content">본문 바로가기</a>
+  </div>
+  <div class="wrap" id="wrap">
+   <!--<div id="header"></div>-->
+   <div id="header" class="main-header">
+    <input id="envUrl" hidden value="https://www.tworld.co.kr">
+    <div class="main-header__inner">
+     <!-- header 상단 기본 -->
+     <div class="main-header__top">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__logo">
+        <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+       </div>
+       <div class="main-header__util-item" id="gnb_login">
+        <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+        <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+       </div>
+       <div class="main-header__family-site family-list">
+        <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+       </div>
+      </div>
+     </div><!-- // header 상단 기본 --> <!-- GNB 기본 -->
+     <div class="main-header__bottom">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu gnb">
+        <!-- 활성화된 메뉴의 a 태그에 is-active -->
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+        </div>
+        <div class="gnb__item">
+         <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+        </div>
+       </div>
+       <div class="main-header__util header-util">
+        <div class="header-util__item">
+         <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB 기본 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T membership main --> <!-- 혜택 브랜드 --> <!-- 20230414 2depth 삭제 --> <!-- GNB 서브페이지 (상품서비스) -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+        </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+       </div>
+      </div>
+     </div><!-- // GNB 서브페이지 (my) --> <!-- //20230414 2depth 삭제 --> <!-- //혜택 브랜드 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 혜택 프로그램 --> <!-- GNB Family menu -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB Family menu --> <!-- //혜택 프로그램 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 나의 T 멤버십 --> <!-- GNB Family menu -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB Family menu --> <!-- //나의 T 멤버십 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T 멤버십 안내 --> <!-- GNB Family menu -->
+     <div class="main-header__lnb" style="display: none;">
+      <div class="navi_cont">
+       <!-- 20230411 클래스명 변경 -->
+       <div class="main-header__menu header-lnb">
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+        </div>
+        <div class="header-lnb__item">
+         <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+        </div>
+       </div>
+      </div>
+     </div><!-- // GNB Family menu --> <!-- //T 멤버십 안내 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> -->
+    </div>
+   </div>
+   <div class="container">
+    <div id="content">
+     <div class="inr-wrap">
+      <div class="title-area">
+       <h1>파리바게뜨</h1><input type="hidden" name="brandId" id="brandId" value="1053"> <input type="hidden" name="brandName" id="brandName" value="파리바게뜨">
+      </div><!-- 브랜드 상단 영역 -->
+      <div class="brnad-info-top">
+       <div class="bit-left">
+        <p class="tit">대한민국 베이커리 문화를 선도하는 건강한 베이커리</p>
+        <div class="badge-list">
+         <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+        </div>
+       </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635235481847.png" alt="파리바게뜨"> </span>
+      </div><!-- //브랜드 상단 영역 --> <!-- 브랜드 선택 영역 -->
+      <div class="brand-sel-box">
+       <div class="fc-select">
+        <span>고객님이 선택하신 브랜드는</span>
+        <div class="dropdown" data-selectbox>
+         <a href="javascript:;" data-set-button> <span></span></a>
+         <div data-set-list>
+          <ul id="sel-ul">
+           <!-- 선택된 값에 'data-selected' 추가 -->
+           <li id="53" data-selected="data-selected"><a>베이커리</a></li>
+           <li id="54"><a>외식</a></li>
+           <li id="55"><a>카페/아이스크림</a></li>
+           <li id="56"><a>피자/치킨</a></li>
+           <li id="48"><a>금융/통신</a></li>
+           <li id="112"><a>렌탈</a></li>
+           <li id="116"><a>반려동물</a></li>
+           <li id="49"><a>생활/교통</a></li>
+           <li id="50"><a>쇼핑몰</a></li>
+           <li id="51"><a>패션/뷰티</a></li>
+           <li id="52"><a>편의점</a></li>
+           <li id="57"><a>교육</a></li>
+           <li id="109"><a>액티비티</a></li>
+           <li id="59"><a>여행</a></li>
+           <li id="60"><a>영화/공연/전시</a></li>
+           <li id="61"><a>콘텐츠</a></li>
+           <li id="110"><a>테마파크</a></li>
+          </ul>
+         </div>
+        </div>
+        <div class="dropdown" data-selectbox>
+         <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+         <div id="smallList" data-set-list>
+          <ul id="sel-list">
+           <li id="1053" data-selected="data-selected"><a>파리바게뜨</a></li>
+           <li id="1084"><a>뚜레쥬르</a></li>
+           <li id="1121"><a>파리크라상</a></li>
+           <li id="1151"><a>빌리엔젤</a></li>
+           <li id="1097"><a>열린베이커리</a></li>
+          </ul>
+         </div>
+        </div><span>입니다.</span>
+       </div>
+      </div><!-- //브랜드 선택 영역 --> <!-- 브랜드 상세 혜택 소개 영역 -->
+      <div class="brand-detail">
+       <div class="bd-top">
+        <div class="cate">
+         <span>EAT </span> <span>베이커리</span> <input type="hidden" name="categoryMid" id="categoryMid" value="53"> <input type="hidden" name="categoryMname" id="categoryMname" value="베이커리">
+        </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">127094</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="127094"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+       </div>
+       <div class="detail-list">
+        <dl>
+         <dt>
+          혜택
+         </dt>
+         <dd>
+          <dl class="dl-bnf">
+           <dt>
+            할인형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+          <dl class="dl-bnf">
+           <dt>
+            적립형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+         </dd>
+        </dl>
+        <dl>
+         <dt>
+          유의사항
+         </dt>
+         <dd>
+          <div class="notice">
+           <div class="explain-area pd-no">
+            <ul class="list-dot">
+             <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+             <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+             <li>횟수 제한 : 1일 1회 결제금액 1천 원 이상 시 할인 또는 적립 가능</li>
+             <li>최대 할인 가능 : 플라스틱 카드 이용 시 일 최대 10,000원 할인</li>
+             <li>최대 할인 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000원, SILVER 10,000원 할인</li>
+             <li>최대 적립 가능 : 플라스틱 카드 이용 시 일 최대 10,000P 적립</li>
+             <li>최대 적립 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000P, SILVER 10,000P 적립</li>
+             <li>결제 전 직원에게 T 멤버십 카드 제시</li>
+             <li>타 적립 및 쿠폰 동시 적용 불가</li>
+             <li>제외 매장 : 일부 점포(휴게소, 역사, 인샵, 특수매장 등) 제외 됩니다.</li>
+             <li>적립된 포인트는 ‘적립 예정’ 포인트로 표시되며, 결제일 1일 이후부터 사용 가능 포인트로 전환됩니다.</li>
+            </ul>
+           </div>
+          </div>
+         </dd>
+        </dl>
+        <dl>
+         <dt>
+          문의 및 상담
+         </dt>
+         <dd>
+          <ul class="list-dash">
+           <li>TEL : 080-731-2027</li>
+           <li>HOME : <a href="javascript:goHomePage('https://www.paris.co.kr/')">https://www.paris.co.kr/</a></li>
+          </ul>
+         </dd>
+        </dl>
+       </div>
+      </div>
+     </div><!-- //브랜드 상세 혜택 소개 영역 --> <!-- 비슷한 혜택 브랜드 추천 영역 -->
+     <div class="similar-area">
+      <div class="inr-wrap">
+       <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+       <ul class="benefit-list">
+        <li><a href="javascript:;" class="benefit-box" id="1121" data-title="파리크라상" data-idx="0" data-cate-id="53" data-cate-name="베이커리">
+          <div class="bnf-top">
+           <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635236220043.png" alt="파리크라상"> </span> <span class="sort">베이커리</span> <span class="brand">파리크라상</span>
+           <div class="badge-list">
+            <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+           </div>
+          </div>
+          <div class="bnf-info">
+           <dl class="dl-bnf">
+            <dt>
+             할인형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+           <dl class="dl-bnf">
+            <dt>
+             적립형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+          </div><span class="btn-round gra">자세히 보기</span> </a></li>
+        <li><a href="javascript:;" class="benefit-box" id="1151" data-title="빌리엔젤" data-idx="1" data-cate-id="53" data-cate-name="베이커리">
+          <div class="bnf-top">
+           <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202209/1663893303634.png" alt="빌리엔젤"> </span> <span class="sort">베이커리</span> <span class="brand">빌리엔젤</span>
+           <div class="badge-list">
+            <i class="badge-bg-radius skyBlue">할인</i>
+           </div>
+          </div>
+          <div class="bnf-info">
+           <dl class="dl-bnf">
+            <dt>
+             할인형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+             </div>
+            </dd>
+           </dl>
+           <dl class="dl-bnf">
+            <dt>
+             적립형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+             </div>
+            </dd>
+           </dl>
+          </div><span class="btn-round gra">자세히 보기</span> </a></li>
+        <li><a href="javascript:;" class="benefit-box" id="1084" data-title="뚜레쥬르" data-idx="2" data-cate-id="53" data-cate-name="베이커리">
+          <div class="bnf-top">
+           <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635148435539.png" alt="뚜레쥬르"> </span> <span class="sort">베이커리</span> <span class="brand">뚜레쥬르</span>
+           <div class="badge-list">
+            <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+           </div>
+          </div>
+          <div class="bnf-info">
+           <dl class="dl-bnf">
+            <dt>
+             할인형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150원 할인
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50원 할인
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+           <dl class="dl-bnf">
+            <dt>
+             적립형
+            </dt>
+            <dd>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150P 적립
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50P 적립
+             </div>
+             <div class="info">
+              <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+             </div>
+            </dd>
+           </dl>
+          </div><span class="btn-round gra">자세히 보기</span> </a></li>
+       </ul>
+      </div>
+     </div><!-- //비슷한 혜택 브랜드 추천 영역 -->
+    </div>
+   </div><!--         <div id="footer"></div> -->
+   <div id="footer" class="main-footer">
+    <a href="#" class="footer__go-top"><span class="hidden">상단으로 이동</span></a>
+    <div class="main-footer__top">
+     <div class="footer_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="bar-list">
+       <div class="bar-list__item">
+        <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+       </div><!-- 2023-05-23 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+       </div><!-- 2023-05-23 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+       </div>
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+       </div><!-- 230515 수정 -->
+       <div class="bar-list__item">
+        <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+       </div>
+       <div class="bar-list__item">
+        <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+       </div>
+      </div>
+     </div>
+    </div>
+    <div class="main-footer__bottom">
+     <div class="footer_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="logo-list">
+       <div class="logo-list__item">
+        <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+          26년 연속 1위</span></a>
+       </div><!-- 2023-05-30 수정 -->
+       <div class="logo-list__item">
+        <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+          23년 연속 1위</span></a>
+       </div><!-- 20230508 수정 -->
+       <div class="logo-list__item">
+        <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+          25년 연속 1위</span></a>
+       </div><!-- 20230508 수정 -->
+       <div class="logo-list__item">
+        <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+       </div><!-- 20230508 수정 -->
+      </div>
+      <div class="footer__info-box width-auto">
+       <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+       <div class="column-box__item">
+        <div class="column-box__inner">
+         <div class="bar-list bar-list--narrow">
+          <div class="bar-list__item">
+           SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+           <br>
+           (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+          </div>
+          <hr class="bar-list--narrow bar-list--grey">
+          <div class="bar-list__item">
+           <strong>고객센터</strong>
+          </div>
+          <div class="bar-list__item">
+           대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+          </div><!-- 2023-05-23 수정 -->
+          <hr class="bar-list__line">
+          <div class="bar-list__item">
+           인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+          </div><!-- 2023-05-23 수정 -->
+          <div class="bar-list__item">
+           T 멤버십 마켓 : 1599-3377(유료)
+          </div><!-- 2023-05-23 수정 -->
+         </div>
+         <div class="bar-list bar-list--narrow bar-list--grey">
+          <div class="bar-list__item">
+           대표이사/사장 : 유영상
+          </div>
+          <div class="bar-list__item">
+           사업자등록번호 : 104-81-37225
+          </div>
+          <div class="bar-list__item">
+           판매허가번호 : 중구 02923호
+          </div>
+          <div class="bar-list__item">
+           <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+          </div>
+          <hr class="bar-list__line">
+          <div class="bar-list__item">
+           서울특별시 중구 을지로 65
+          </div>
+          <hr class="bar-list__line">
+          <div class="bar-list__item copyright">
+           COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+          </div>
+         </div>
+        </div>
+       </div>
+       <div class="column-box__item column-box__item--right">
+        <div class="column-box__inner">
+         <div class="site-list">
+          <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+          <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+           <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+           <div class="family-list" data-element="commonToggle__layer">
+            <div class="family-list__item">
+             <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+            </div><!-- 2023-05-30 수정 -->
+            <div class="family-list__item">
+             <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+            </div>
+            <div class="family-list__item">
+             <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+            </div>
+            <div class="family-list__item">
+             <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+            </div>
+            <div class="family-list__item">
+             <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+            </div>
+           </div>
+          </div>
+         </div>
+         <div class="social-list">
+          <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+         </div>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+   <script type="text/javascript" src="/js/benefitbrand/MPW_D001_P03-f38ad4ae8f7e63be2335a3a34ed7a5af.js"></script>
+  </div>
+  <div class="toast01" data-toast="toastContainer" data-y="bottom" data-duration="800" data-pos="20" data-timer="3000">
+   <span id="toastContainer"></span>
+  </div>
+  <div class="loadingbar-area"></div>
+ </body>
+</html>
+<head>
+ <title>T 멤버십</title>
+ <meta charset="UTF-8">
+ <meta http-equiv="Content-Type" content="text/html">
+ <meta http-equiv="Content-Script-Type" content="text/javascript">
+ <meta http-equiv="Content-Style-Type" content="text/css">
+ <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, viewport-fit=cover">
+ <meta http-equiv="X-UA-compatible" content="IE=edge,chrome=1">
+ <link rel="shortcut icon" href="https://cdn.sktmembership.co.kr/mps.pc/favicon.ico" type="image/x-icon">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/poc/inc/css/footer.css">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/jquery-ui.min.css">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/swiper.min.css">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/common.css">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/style.css">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/wait.css">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/benefit.css">
+ <link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/re_gnb.css">
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-3.4.1.min.js"></script>
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-ui.min.js"></script>
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/swiper.min.js"></script>
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/common.js"></script>
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/promise-polyfill.min.js"></script>
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/common/jsrender.js"></script>
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/axios.min.js"></script>
+ <script>
+        var CDN_PATH = "https:\/\/cdn.sktmembership.co.kr\/mps.pc";
+        var ENV = "prd";
+        var IS_LOGIN = false;
+        var IS_MBR_CARD = false;
+    </script>
+ <script type="text/javascript" src="/js/common-4c70bc9059822c175d8f8e59ac010eef.js"></script>
+ <script type="text/javascript" src="/js/netfunnel-194808761f66576464c07f70ba55a195.js"></script><!--     <link rel="stylesheet" type="text/css" th:href="@{${_config.url('/poc/gnb/inc/css/gnb.css')}}"> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/js/jquery.gnb.js')}}"></script> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/js/gnb.js')}}"></script> --> <!--     <script type="text/javascript" th:src="@{${_config.url('/poc/gnb/inc/cmn/gnb_cmn.js')}}"></script> --> <!-- 	<script type="text/javascript" th:src="@{'/poc/gnb/inc/cmn/re_gnb.js'}"></script> -->
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/js/re_gnb.js"></script>
+ <script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/cmn/common_url_new.js"></script>
+ <script src="https://xtr.tos.sktelecom.com/js/xtractor_script.js"></script>
+</head>
+<title>T 멤버십</title>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Type" content="text/html">
+<meta http-equiv="Content-Script-Type" content="text/javascript">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, viewport-fit=cover">
+<meta http-equiv="X-UA-compatible" content="IE=edge,chrome=1">
+<link rel="shortcut icon" href="https://cdn.sktmembership.co.kr/mps.pc/favicon.ico" type="image/x-icon">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/poc/inc/css/footer.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/jquery-ui.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/plugin/swiper.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/common.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/style.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/wait.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/benefit.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.sktmembership.co.kr/mps.pc/resources/css/re_gnb.css">
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-3.4.1.min.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/jquery-ui.min.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/plugin/swiper.min.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/resources/js/common.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/promise-polyfill.min.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/common/jsrender.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/js/lib/axios.min.js"></script>
+<script>
+        var CDN_PATH = "https:\/\/cdn.sktmembership.co.kr\/mps.pc";
+        var ENV = "prd";
+        var IS_LOGIN = false;
+        var IS_MBR_CARD = false;
+    </script>
+<script type="text/javascript" src="/js/common-4c70bc9059822c175d8f8e59ac010eef.js"></script>
+<script type="text/javascript" src="/js/netfunnel-194808761f66576464c07f70ba55a195.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/js/re_gnb.js"></script>
+<script type="text/javascript" src="https://cdn.sktmembership.co.kr/mps.pc/poc/gnb/inc/cmn/common_url_new.js"></script>
+<script src="https://xtr.tos.sktelecom.com/js/xtractor_script.js"></script>
+<body>
+ <div class="accessbility">
+  <a href="#content">본문 바로가기</a>
+ </div>
+ <div class="wrap" id="wrap">
+  <!--<div id="header"></div>-->
+  <div id="header" class="main-header">
+   <input id="envUrl" hidden value="https://www.tworld.co.kr">
+   <div class="main-header__inner">
+    <!-- header 상단 기본 -->
+    <div class="main-header__top">
+     <div class="navi_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="main-header__logo">
+       <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+      </div>
+      <div class="main-header__util-item" id="gnb_login">
+       <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+       <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+      </div>
+      <div class="main-header__family-site family-list">
+       <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+      </div>
+     </div>
+    </div><!-- // header 상단 기본 --> <!-- GNB 기본 -->
+    <div class="main-header__bottom">
+     <div class="navi_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="main-header__menu gnb">
+       <!-- 활성화된 메뉴의 a 태그에 is-active -->
+       <div class="gnb__item">
+        <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+       </div>
+       <div class="gnb__item">
+        <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+       </div>
+       <div class="gnb__item">
+        <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+       </div>
+       <div class="gnb__item">
+        <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+       </div>
+       <div class="gnb__item">
+        <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+       </div>
+      </div>
+      <div class="main-header__util header-util">
+       <div class="header-util__item">
+        <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+       </div>
+      </div>
+     </div>
+    </div><!-- // GNB 기본 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T membership main --> <!-- 혜택 브랜드 --> <!-- 20230414 2depth 삭제 --> <!-- GNB 서브페이지 (상품서비스) -->
+    <div class="main-header__lnb" style="display: none;">
+     <div class="navi_cont">
+      <div class="main-header__menu header-lnb">
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+       </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+      </div>
+     </div>
+    </div><!-- // GNB 서브페이지 (my) --> <!-- //20230414 2depth 삭제 --> <!-- //혜택 브랜드 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 혜택 프로그램 --> <!-- GNB Family menu -->
+    <div class="main-header__lnb" style="display: none;">
+     <div class="navi_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="main-header__menu header-lnb">
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+       </div>
+      </div>
+     </div>
+    </div><!-- // GNB Family menu --> <!-- //혜택 프로그램 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 나의 T 멤버십 --> <!-- GNB Family menu -->
+    <div class="main-header__lnb" style="display: none;">
+     <div class="navi_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="main-header__menu header-lnb">
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+       </div>
+      </div>
+     </div>
+    </div><!-- // GNB Family menu --> <!-- //나의 T 멤버십 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T 멤버십 안내 --> <!-- GNB Family menu -->
+    <div class="main-header__lnb" style="display: none;">
+     <div class="navi_cont">
+      <!-- 20230411 클래스명 변경 -->
+      <div class="main-header__menu header-lnb">
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+       </div>
+       <div class="header-lnb__item">
+        <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+       </div>
+      </div>
+     </div>
+    </div><!-- // GNB Family menu --> <!-- //T 멤버십 안내 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> -->
+   </div>
+  </div>
+  <div class="container">
+   <div id="content">
+    <div class="inr-wrap">
+     <div class="title-area">
+      <h1>파리바게뜨</h1><input type="hidden" name="brandId" id="brandId" value="1053"> <input type="hidden" name="brandName" id="brandName" value="파리바게뜨">
+     </div><!-- 브랜드 상단 영역 -->
+     <div class="brnad-info-top">
+      <div class="bit-left">
+       <p class="tit">대한민국 베이커리 문화를 선도하는 건강한 베이커리</p>
+       <div class="badge-list">
+        <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+       </div>
+      </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635235481847.png" alt="파리바게뜨"> </span>
+     </div><!-- //브랜드 상단 영역 --> <!-- 브랜드 선택 영역 -->
+     <div class="brand-sel-box">
+      <div class="fc-select">
+       <span>고객님이 선택하신 브랜드는</span>
+       <div class="dropdown" data-selectbox>
+        <a href="javascript:;" data-set-button> <span></span></a>
+        <div data-set-list>
+         <ul id="sel-ul">
+          <!-- 선택된 값에 'data-selected' 추가 -->
+          <li id="53" data-selected="data-selected"><a>베이커리</a></li>
+          <li id="54"><a>외식</a></li>
+          <li id="55"><a>카페/아이스크림</a></li>
+          <li id="56"><a>피자/치킨</a></li>
+          <li id="48"><a>금융/통신</a></li>
+          <li id="112"><a>렌탈</a></li>
+          <li id="116"><a>반려동물</a></li>
+          <li id="49"><a>생활/교통</a></li>
+          <li id="50"><a>쇼핑몰</a></li>
+          <li id="51"><a>패션/뷰티</a></li>
+          <li id="52"><a>편의점</a></li>
+          <li id="57"><a>교육</a></li>
+          <li id="109"><a>액티비티</a></li>
+          <li id="59"><a>여행</a></li>
+          <li id="60"><a>영화/공연/전시</a></li>
+          <li id="61"><a>콘텐츠</a></li>
+          <li id="110"><a>테마파크</a></li>
+         </ul>
+        </div>
+       </div>
+       <div class="dropdown" data-selectbox>
+        <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+        <div id="smallList" data-set-list>
+         <ul id="sel-list">
+          <li id="1053" data-selected="data-selected"><a>파리바게뜨</a></li>
+          <li id="1084"><a>뚜레쥬르</a></li>
+          <li id="1121"><a>파리크라상</a></li>
+          <li id="1151"><a>빌리엔젤</a></li>
+          <li id="1097"><a>열린베이커리</a></li>
+         </ul>
+        </div>
+       </div><span>입니다.</span>
+      </div>
+     </div><!-- //브랜드 선택 영역 --> <!-- 브랜드 상세 혜택 소개 영역 -->
+     <div class="brand-detail">
+      <div class="bd-top">
+       <div class="cate">
+        <span>EAT </span> <span>베이커리</span> <input type="hidden" name="categoryMid" id="categoryMid" value="53"> <input type="hidden" name="categoryMname" id="categoryMname" value="베이커리">
+       </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">127094</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="127094"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+      </div>
+      <div class="detail-list">
+       <dl>
+        <dt>
+         혜택
+        </dt>
+        <dd>
+         <dl class="dl-bnf">
+          <dt>
+           할인형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+           </div>
+          </dd>
+         </dl>
+         <dl class="dl-bnf">
+          <dt>
+           적립형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+           </div>
+          </dd>
+         </dl>
+        </dd>
+       </dl>
+       <dl>
+        <dt>
+         유의사항
+        </dt>
+        <dd>
+         <div class="notice">
+          <div class="explain-area pd-no">
+           <ul class="list-dot">
+            <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+            <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+            <li>횟수 제한 : 1일 1회 결제금액 1천 원 이상 시 할인 또는 적립 가능</li>
+            <li>최대 할인 가능 : 플라스틱 카드 이용 시 일 최대 10,000원 할인</li>
+            <li>최대 할인 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000원, SILVER 10,000원 할인</li>
+            <li>최대 적립 가능 : 플라스틱 카드 이용 시 일 최대 10,000P 적립</li>
+            <li>최대 적립 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000P, SILVER 10,000P 적립</li>
+            <li>결제 전 직원에게 T 멤버십 카드 제시</li>
+            <li>타 적립 및 쿠폰 동시 적용 불가</li>
+            <li>제외 매장 : 일부 점포(휴게소, 역사, 인샵, 특수매장 등) 제외 됩니다.</li>
+            <li>적립된 포인트는 ‘적립 예정’ 포인트로 표시되며, 결제일 1일 이후부터 사용 가능 포인트로 전환됩니다.</li>
+           </ul>
+          </div>
+         </div>
+        </dd>
+       </dl>
+       <dl>
+        <dt>
+         문의 및 상담
+        </dt>
+        <dd>
+         <ul class="list-dash">
+          <li>TEL : 080-731-2027</li>
+          <li>HOME : <a href="javascript:goHomePage('https://www.paris.co.kr/')">https://www.paris.co.kr/</a></li>
+         </ul>
+        </dd>
+       </dl>
+      </div>
+     </div>
+    </div><!-- //브랜드 상세 혜택 소개 영역 --> <!-- 비슷한 혜택 브랜드 추천 영역 -->
+    <div class="similar-area">
+     <div class="inr-wrap">
+      <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+      <ul class="benefit-list">
+       <li><a href="javascript:;" class="benefit-box" id="1121" data-title="파리크라상" data-idx="0" data-cate-id="53" data-cate-name="베이커리">
+         <div class="bnf-top">
+          <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635236220043.png" alt="파리크라상"> </span> <span class="sort">베이커리</span> <span class="brand">파리크라상</span>
+          <div class="badge-list">
+           <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+          </div>
+         </div>
+         <div class="bnf-info">
+          <dl class="dl-bnf">
+           <dt>
+            할인형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+          <dl class="dl-bnf">
+           <dt>
+            적립형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+         </div><span class="btn-round gra">자세히 보기</span> </a></li>
+       <li><a href="javascript:;" class="benefit-box" id="1151" data-title="빌리엔젤" data-idx="1" data-cate-id="53" data-cate-name="베이커리">
+         <div class="bnf-top">
+          <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202209/1663893303634.png" alt="빌리엔젤"> </span> <span class="sort">베이커리</span> <span class="brand">빌리엔젤</span>
+          <div class="badge-list">
+           <i class="badge-bg-radius skyBlue">할인</i>
+          </div>
+         </div>
+         <div class="bnf-info">
+          <dl class="dl-bnf">
+           <dt>
+            할인형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+            </div>
+           </dd>
+          </dl>
+          <dl class="dl-bnf">
+           <dt>
+            적립형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+            </div>
+           </dd>
+          </dl>
+         </div><span class="btn-round gra">자세히 보기</span> </a></li>
+       <li><a href="javascript:;" class="benefit-box" id="1084" data-title="뚜레쥬르" data-idx="2" data-cate-id="53" data-cate-name="베이커리">
+         <div class="bnf-top">
+          <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635148435539.png" alt="뚜레쥬르"> </span> <span class="sort">베이커리</span> <span class="brand">뚜레쥬르</span>
+          <div class="badge-list">
+           <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+          </div>
+         </div>
+         <div class="bnf-info">
+          <dl class="dl-bnf">
+           <dt>
+            할인형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150원 할인
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50원 할인
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+          <dl class="dl-bnf">
+           <dt>
+            적립형
+           </dt>
+           <dd>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150P 적립
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50P 적립
+            </div>
+            <div class="info">
+             <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+            </div>
+           </dd>
+          </dl>
+         </div><span class="btn-round gra">자세히 보기</span> </a></li>
+      </ul>
+     </div>
+    </div><!-- //비슷한 혜택 브랜드 추천 영역 -->
+   </div>
+  </div><!--         <div id="footer"></div> -->
+  <div id="footer" class="main-footer">
+   <a href="#" class="footer__go-top"><span class="hidden">상단으로 이동</span></a>
+   <div class="main-footer__top">
+    <div class="footer_cont">
+     <!-- 20230411 클래스명 변경 -->
+     <div class="bar-list">
+      <div class="bar-list__item">
+       <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+      </div><!-- 2023-05-23 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+      </div><!-- 2023-05-23 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+      </div><!-- 230515 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+      </div><!-- 230515 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+      </div><!-- 230515 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+      </div><!-- 230515 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+      </div><!-- 230515 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+      </div>
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+      </div><!-- 230515 수정 -->
+      <div class="bar-list__item">
+       <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+      </div><!-- 230515 수정 -->
+      <div class="bar-list__item">
+       <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+      </div>
+      <div class="bar-list__item">
+       <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+      </div>
+     </div>
+    </div>
+   </div>
+   <div class="main-footer__bottom">
+    <div class="footer_cont">
+     <!-- 20230411 클래스명 변경 -->
+     <div class="logo-list">
+      <div class="logo-list__item">
+       <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+         26년 연속 1위</span></a>
+      </div><!-- 2023-05-30 수정 -->
+      <div class="logo-list__item">
+       <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+         23년 연속 1위</span></a>
+      </div><!-- 20230508 수정 -->
+      <div class="logo-list__item">
+       <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+         25년 연속 1위</span></a>
+      </div><!-- 20230508 수정 -->
+      <div class="logo-list__item">
+       <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+      </div><!-- 20230508 수정 -->
+     </div>
+     <div class="footer__info-box width-auto">
+      <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+      <div class="column-box__item">
+       <div class="column-box__inner">
+        <div class="bar-list bar-list--narrow">
+         <div class="bar-list__item">
+          SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+          <br>
+          (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+         </div>
+         <hr class="bar-list--narrow bar-list--grey">
+         <div class="bar-list__item">
+          <strong>고객센터</strong>
+         </div>
+         <div class="bar-list__item">
+          대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+         </div><!-- 2023-05-23 수정 -->
+         <hr class="bar-list__line">
+         <div class="bar-list__item">
+          인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+         </div><!-- 2023-05-23 수정 -->
+         <div class="bar-list__item">
+          T 멤버십 마켓 : 1599-3377(유료)
+         </div><!-- 2023-05-23 수정 -->
+        </div>
+        <div class="bar-list bar-list--narrow bar-list--grey">
+         <div class="bar-list__item">
+          대표이사/사장 : 유영상
+         </div>
+         <div class="bar-list__item">
+          사업자등록번호 : 104-81-37225
+         </div>
+         <div class="bar-list__item">
+          판매허가번호 : 중구 02923호
+         </div>
+         <div class="bar-list__item">
+          <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+         </div>
+         <hr class="bar-list__line">
+         <div class="bar-list__item">
+          서울특별시 중구 을지로 65
+         </div>
+         <hr class="bar-list__line">
+         <div class="bar-list__item copyright">
+          COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+         </div>
+        </div>
+       </div>
+      </div>
+      <div class="column-box__item column-box__item--right">
+       <div class="column-box__inner">
+        <div class="site-list">
+         <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+         <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+          <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+          <div class="family-list" data-element="commonToggle__layer">
+           <div class="family-list__item">
+            <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+           </div><!-- 2023-05-30 수정 -->
+           <div class="family-list__item">
+            <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+           </div>
+           <div class="family-list__item">
+            <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+           </div>
+           <div class="family-list__item">
+            <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+           </div>
+           <div class="family-list__item">
+            <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+           </div>
+           <div class="family-list__item">
+            <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+           </div>
+           <div class="family-list__item">
+            <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+           </div>
+           <div class="family-list__item">
+            <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+           </div>
+           <div class="family-list__item">
+            <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+           </div>
+          </div>
+         </div>
+        </div>
+        <div class="social-list">
+         <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+  <script type="text/javascript" src="/js/benefitbrand/MPW_D001_P03-f38ad4ae8f7e63be2335a3a34ed7a5af.js"></script>
+ </div>
+ <div class="toast01" data-toast="toastContainer" data-y="bottom" data-duration="800" data-pos="20" data-timer="3000">
+  <span id="toastContainer"></span>
+ </div>
+ <div class="loadingbar-area"></div>
+</body>
+<div class="accessbility">
+ <a href="#content">본문 바로가기</a>
+</div>
+<a href="#content">본문 바로가기</a>
+<div class="wrap" id="wrap">
+ <!--<div id="header"></div>-->
+ <div id="header" class="main-header">
+  <input id="envUrl" hidden value="https://www.tworld.co.kr">
+  <div class="main-header__inner">
+   <!-- header 상단 기본 -->
+   <div class="main-header__top">
+    <div class="navi_cont">
+     <!-- 20230411 클래스명 변경 -->
+     <div class="main-header__logo">
+      <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+     </div>
+     <div class="main-header__util-item" id="gnb_login">
+      <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+      <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+     </div>
+     <div class="main-header__family-site family-list">
+      <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+     </div>
+    </div>
+   </div><!-- // header 상단 기본 --> <!-- GNB 기본 -->
+   <div class="main-header__bottom">
+    <div class="navi_cont">
+     <!-- 20230411 클래스명 변경 -->
+     <div class="main-header__menu gnb">
+      <!-- 활성화된 메뉴의 a 태그에 is-active -->
+      <div class="gnb__item">
+       <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+      </div>
+      <div class="gnb__item">
+       <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+      </div>
+      <div class="gnb__item">
+       <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+      </div>
+      <div class="gnb__item">
+       <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+      </div>
+      <div class="gnb__item">
+       <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+      </div>
+     </div>
+     <div class="main-header__util header-util">
+      <div class="header-util__item">
+       <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+      </div>
+     </div>
+    </div>
+   </div><!-- // GNB 기본 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T membership main --> <!-- 혜택 브랜드 --> <!-- 20230414 2depth 삭제 --> <!-- GNB 서브페이지 (상품서비스) -->
+   <div class="main-header__lnb" style="display: none;">
+    <div class="navi_cont">
+     <div class="main-header__menu header-lnb">
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+      </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+     </div>
+    </div>
+   </div><!-- // GNB 서브페이지 (my) --> <!-- //20230414 2depth 삭제 --> <!-- //혜택 브랜드 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 혜택 프로그램 --> <!-- GNB Family menu -->
+   <div class="main-header__lnb" style="display: none;">
+    <div class="navi_cont">
+     <!-- 20230411 클래스명 변경 -->
+     <div class="main-header__menu header-lnb">
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+      </div>
+     </div>
+    </div>
+   </div><!-- // GNB Family menu --> <!-- //혜택 프로그램 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 나의 T 멤버십 --> <!-- GNB Family menu -->
+   <div class="main-header__lnb" style="display: none;">
+    <div class="navi_cont">
+     <!-- 20230411 클래스명 변경 -->
+     <div class="main-header__menu header-lnb">
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+      </div>
+     </div>
+    </div>
+   </div><!-- // GNB Family menu --> <!-- //나의 T 멤버십 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T 멤버십 안내 --> <!-- GNB Family menu -->
+   <div class="main-header__lnb" style="display: none;">
+    <div class="navi_cont">
+     <!-- 20230411 클래스명 변경 -->
+     <div class="main-header__menu header-lnb">
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+      </div>
+      <div class="header-lnb__item">
+       <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+      </div>
+     </div>
+    </div>
+   </div><!-- // GNB Family menu --> <!-- //T 멤버십 안내 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> -->
+  </div>
+ </div>
+ <div class="container">
+  <div id="content">
+   <div class="inr-wrap">
+    <div class="title-area">
+     <h1>파리바게뜨</h1><input type="hidden" name="brandId" id="brandId" value="1053"> <input type="hidden" name="brandName" id="brandName" value="파리바게뜨">
+    </div><!-- 브랜드 상단 영역 -->
+    <div class="brnad-info-top">
+     <div class="bit-left">
+      <p class="tit">대한민국 베이커리 문화를 선도하는 건강한 베이커리</p>
+      <div class="badge-list">
+       <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+      </div>
+     </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635235481847.png" alt="파리바게뜨"> </span>
+    </div><!-- //브랜드 상단 영역 --> <!-- 브랜드 선택 영역 -->
+    <div class="brand-sel-box">
+     <div class="fc-select">
+      <span>고객님이 선택하신 브랜드는</span>
+      <div class="dropdown" data-selectbox>
+       <a href="javascript:;" data-set-button> <span></span></a>
+       <div data-set-list>
+        <ul id="sel-ul">
+         <!-- 선택된 값에 'data-selected' 추가 -->
+         <li id="53" data-selected="data-selected"><a>베이커리</a></li>
+         <li id="54"><a>외식</a></li>
+         <li id="55"><a>카페/아이스크림</a></li>
+         <li id="56"><a>피자/치킨</a></li>
+         <li id="48"><a>금융/통신</a></li>
+         <li id="112"><a>렌탈</a></li>
+         <li id="116"><a>반려동물</a></li>
+         <li id="49"><a>생활/교통</a></li>
+         <li id="50"><a>쇼핑몰</a></li>
+         <li id="51"><a>패션/뷰티</a></li>
+         <li id="52"><a>편의점</a></li>
+         <li id="57"><a>교육</a></li>
+         <li id="109"><a>액티비티</a></li>
+         <li id="59"><a>여행</a></li>
+         <li id="60"><a>영화/공연/전시</a></li>
+         <li id="61"><a>콘텐츠</a></li>
+         <li id="110"><a>테마파크</a></li>
+        </ul>
+       </div>
+      </div>
+      <div class="dropdown" data-selectbox>
+       <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+       <div id="smallList" data-set-list>
+        <ul id="sel-list">
+         <li id="1053" data-selected="data-selected"><a>파리바게뜨</a></li>
+         <li id="1084"><a>뚜레쥬르</a></li>
+         <li id="1121"><a>파리크라상</a></li>
+         <li id="1151"><a>빌리엔젤</a></li>
+         <li id="1097"><a>열린베이커리</a></li>
+        </ul>
+       </div>
+      </div><span>입니다.</span>
+     </div>
+    </div><!-- //브랜드 선택 영역 --> <!-- 브랜드 상세 혜택 소개 영역 -->
+    <div class="brand-detail">
+     <div class="bd-top">
+      <div class="cate">
+       <span>EAT </span> <span>베이커리</span> <input type="hidden" name="categoryMid" id="categoryMid" value="53"> <input type="hidden" name="categoryMname" id="categoryMname" value="베이커리">
+      </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">127094</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="127094"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+     </div>
+     <div class="detail-list">
+      <dl>
+       <dt>
+        혜택
+       </dt>
+       <dd>
+        <dl class="dl-bnf">
+         <dt>
+          할인형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+          </div>
+         </dd>
+        </dl>
+        <dl class="dl-bnf">
+         <dt>
+          적립형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+          </div>
+         </dd>
+        </dl>
+       </dd>
+      </dl>
+      <dl>
+       <dt>
+        유의사항
+       </dt>
+       <dd>
+        <div class="notice">
+         <div class="explain-area pd-no">
+          <ul class="list-dot">
+           <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+           <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+           <li>횟수 제한 : 1일 1회 결제금액 1천 원 이상 시 할인 또는 적립 가능</li>
+           <li>최대 할인 가능 : 플라스틱 카드 이용 시 일 최대 10,000원 할인</li>
+           <li>최대 할인 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000원, SILVER 10,000원 할인</li>
+           <li>최대 적립 가능 : 플라스틱 카드 이용 시 일 최대 10,000P 적립</li>
+           <li>최대 적립 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000P, SILVER 10,000P 적립</li>
+           <li>결제 전 직원에게 T 멤버십 카드 제시</li>
+           <li>타 적립 및 쿠폰 동시 적용 불가</li>
+           <li>제외 매장 : 일부 점포(휴게소, 역사, 인샵, 특수매장 등) 제외 됩니다.</li>
+           <li>적립된 포인트는 ‘적립 예정’ 포인트로 표시되며, 결제일 1일 이후부터 사용 가능 포인트로 전환됩니다.</li>
+          </ul>
+         </div>
+        </div>
+       </dd>
+      </dl>
+      <dl>
+       <dt>
+        문의 및 상담
+       </dt>
+       <dd>
+        <ul class="list-dash">
+         <li>TEL : 080-731-2027</li>
+         <li>HOME : <a href="javascript:goHomePage('https://www.paris.co.kr/')">https://www.paris.co.kr/</a></li>
+        </ul>
+       </dd>
+      </dl>
+     </div>
+    </div>
+   </div><!-- //브랜드 상세 혜택 소개 영역 --> <!-- 비슷한 혜택 브랜드 추천 영역 -->
+   <div class="similar-area">
+    <div class="inr-wrap">
+     <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+     <ul class="benefit-list">
+      <li><a href="javascript:;" class="benefit-box" id="1121" data-title="파리크라상" data-idx="0" data-cate-id="53" data-cate-name="베이커리">
+        <div class="bnf-top">
+         <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635236220043.png" alt="파리크라상"> </span> <span class="sort">베이커리</span> <span class="brand">파리크라상</span>
+         <div class="badge-list">
+          <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+         </div>
+        </div>
+        <div class="bnf-info">
+         <dl class="dl-bnf">
+          <dt>
+           할인형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+           </div>
+          </dd>
+         </dl>
+         <dl class="dl-bnf">
+          <dt>
+           적립형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+           </div>
+          </dd>
+         </dl>
+        </div><span class="btn-round gra">자세히 보기</span> </a></li>
+      <li><a href="javascript:;" class="benefit-box" id="1151" data-title="빌리엔젤" data-idx="1" data-cate-id="53" data-cate-name="베이커리">
+        <div class="bnf-top">
+         <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202209/1663893303634.png" alt="빌리엔젤"> </span> <span class="sort">베이커리</span> <span class="brand">빌리엔젤</span>
+         <div class="badge-list">
+          <i class="badge-bg-radius skyBlue">할인</i>
+         </div>
+        </div>
+        <div class="bnf-info">
+         <dl class="dl-bnf">
+          <dt>
+           할인형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+           </div>
+          </dd>
+         </dl>
+         <dl class="dl-bnf">
+          <dt>
+           적립형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+           </div>
+          </dd>
+         </dl>
+        </div><span class="btn-round gra">자세히 보기</span> </a></li>
+      <li><a href="javascript:;" class="benefit-box" id="1084" data-title="뚜레쥬르" data-idx="2" data-cate-id="53" data-cate-name="베이커리">
+        <div class="bnf-top">
+         <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635148435539.png" alt="뚜레쥬르"> </span> <span class="sort">베이커리</span> <span class="brand">뚜레쥬르</span>
+         <div class="badge-list">
+          <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+         </div>
+        </div>
+        <div class="bnf-info">
+         <dl class="dl-bnf">
+          <dt>
+           할인형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150원 할인
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50원 할인
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+           </div>
+          </dd>
+         </dl>
+         <dl class="dl-bnf">
+          <dt>
+           적립형
+          </dt>
+          <dd>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150P 적립
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50P 적립
+           </div>
+           <div class="info">
+            <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+           </div>
+          </dd>
+         </dl>
+        </div><span class="btn-round gra">자세히 보기</span> </a></li>
+     </ul>
+    </div>
+   </div><!-- //비슷한 혜택 브랜드 추천 영역 -->
+  </div>
+ </div><!--         <div id="footer"></div> -->
+ <div id="footer" class="main-footer">
+  <a href="#" class="footer__go-top"><span class="hidden">상단으로 이동</span></a>
+  <div class="main-footer__top">
+   <div class="footer_cont">
+    <!-- 20230411 클래스명 변경 -->
+    <div class="bar-list">
+     <div class="bar-list__item">
+      <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+     </div><!-- 2023-05-23 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+     </div><!-- 2023-05-23 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+     </div><!-- 230515 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+     </div><!-- 230515 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+     </div><!-- 230515 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+     </div><!-- 230515 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+     </div><!-- 230515 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+     </div>
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+     </div><!-- 230515 수정 -->
+     <div class="bar-list__item">
+      <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+     </div><!-- 230515 수정 -->
+     <div class="bar-list__item">
+      <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+     </div>
+     <div class="bar-list__item">
+      <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+     </div>
+    </div>
+   </div>
+  </div>
+  <div class="main-footer__bottom">
+   <div class="footer_cont">
+    <!-- 20230411 클래스명 변경 -->
+    <div class="logo-list">
+     <div class="logo-list__item">
+      <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+        26년 연속 1위</span></a>
+     </div><!-- 2023-05-30 수정 -->
+     <div class="logo-list__item">
+      <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+        23년 연속 1위</span></a>
+     </div><!-- 20230508 수정 -->
+     <div class="logo-list__item">
+      <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+        25년 연속 1위</span></a>
+     </div><!-- 20230508 수정 -->
+     <div class="logo-list__item">
+      <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+     </div><!-- 20230508 수정 -->
+    </div>
+    <div class="footer__info-box width-auto">
+     <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+     <div class="column-box__item">
+      <div class="column-box__inner">
+       <div class="bar-list bar-list--narrow">
+        <div class="bar-list__item">
+         SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+         <br>
+         (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+        </div>
+        <hr class="bar-list--narrow bar-list--grey">
+        <div class="bar-list__item">
+         <strong>고객센터</strong>
+        </div>
+        <div class="bar-list__item">
+         대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+        </div><!-- 2023-05-23 수정 -->
+        <hr class="bar-list__line">
+        <div class="bar-list__item">
+         인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+        </div><!-- 2023-05-23 수정 -->
+        <div class="bar-list__item">
+         T 멤버십 마켓 : 1599-3377(유료)
+        </div><!-- 2023-05-23 수정 -->
+       </div>
+       <div class="bar-list bar-list--narrow bar-list--grey">
+        <div class="bar-list__item">
+         대표이사/사장 : 유영상
+        </div>
+        <div class="bar-list__item">
+         사업자등록번호 : 104-81-37225
+        </div>
+        <div class="bar-list__item">
+         판매허가번호 : 중구 02923호
+        </div>
+        <div class="bar-list__item">
+         <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+        </div>
+        <hr class="bar-list__line">
+        <div class="bar-list__item">
+         서울특별시 중구 을지로 65
+        </div>
+        <hr class="bar-list__line">
+        <div class="bar-list__item copyright">
+         COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+        </div>
+       </div>
+      </div>
+     </div>
+     <div class="column-box__item column-box__item--right">
+      <div class="column-box__inner">
+       <div class="site-list">
+        <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+        <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+         <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+         <div class="family-list" data-element="commonToggle__layer">
+          <div class="family-list__item">
+           <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+          </div><!-- 2023-05-30 수정 -->
+          <div class="family-list__item">
+           <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+          </div>
+          <div class="family-list__item">
+           <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+          </div>
+          <div class="family-list__item">
+           <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+          </div>
+          <div class="family-list__item">
+           <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+          </div>
+          <div class="family-list__item">
+           <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+          </div>
+          <div class="family-list__item">
+           <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+          </div>
+          <div class="family-list__item">
+           <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+          </div>
+          <div class="family-list__item">
+           <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+          </div>
+         </div>
+        </div>
+       </div>
+       <div class="social-list">
+        <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+ </div>
+ <script type="text/javascript" src="/js/benefitbrand/MPW_D001_P03-f38ad4ae8f7e63be2335a3a34ed7a5af.js"></script>
+</div>
+<div id="header" class="main-header">
+ <input id="envUrl" hidden value="https://www.tworld.co.kr">
+ <div class="main-header__inner">
+  <!-- header 상단 기본 -->
+  <div class="main-header__top">
+   <div class="navi_cont">
+    <!-- 20230411 클래스명 변경 -->
+    <div class="main-header__logo">
+     <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+    </div>
+    <div class="main-header__util-item" id="gnb_login">
+     <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+     <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+    </div>
+    <div class="main-header__family-site family-list">
+     <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+    </div>
+   </div>
+  </div><!-- // header 상단 기본 --> <!-- GNB 기본 -->
+  <div class="main-header__bottom">
+   <div class="navi_cont">
+    <!-- 20230411 클래스명 변경 -->
+    <div class="main-header__menu gnb">
+     <!-- 활성화된 메뉴의 a 태그에 is-active -->
+     <div class="gnb__item">
+      <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+     </div>
+     <div class="gnb__item">
+      <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+     </div>
+     <div class="gnb__item">
+      <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+     </div>
+     <div class="gnb__item">
+      <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+     </div>
+     <div class="gnb__item">
+      <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+     </div>
+    </div>
+    <div class="main-header__util header-util">
+     <div class="header-util__item">
+      <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+     </div>
+    </div>
+   </div>
+  </div><!-- // GNB 기본 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T membership main --> <!-- 혜택 브랜드 --> <!-- 20230414 2depth 삭제 --> <!-- GNB 서브페이지 (상품서비스) -->
+  <div class="main-header__lnb" style="display: none;">
+   <div class="navi_cont">
+    <div class="main-header__menu header-lnb">
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+     </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+    </div>
+   </div>
+  </div><!-- // GNB 서브페이지 (my) --> <!-- //20230414 2depth 삭제 --> <!-- //혜택 브랜드 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 혜택 프로그램 --> <!-- GNB Family menu -->
+  <div class="main-header__lnb" style="display: none;">
+   <div class="navi_cont">
+    <!-- 20230411 클래스명 변경 -->
+    <div class="main-header__menu header-lnb">
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+     </div>
+    </div>
+   </div>
+  </div><!-- // GNB Family menu --> <!-- //혜택 프로그램 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 나의 T 멤버십 --> <!-- GNB Family menu -->
+  <div class="main-header__lnb" style="display: none;">
+   <div class="navi_cont">
+    <!-- 20230411 클래스명 변경 -->
+    <div class="main-header__menu header-lnb">
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+     </div>
+    </div>
+   </div>
+  </div><!-- // GNB Family menu --> <!-- //나의 T 멤버십 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T 멤버십 안내 --> <!-- GNB Family menu -->
+  <div class="main-header__lnb" style="display: none;">
+   <div class="navi_cont">
+    <!-- 20230411 클래스명 변경 -->
+    <div class="main-header__menu header-lnb">
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+     </div>
+     <div class="header-lnb__item">
+      <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+     </div>
+    </div>
+   </div>
+  </div><!-- // GNB Family menu --> <!-- //T 멤버십 안내 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> -->
+ </div>
+</div>
+<input id="envUrl" hidden value="https://www.tworld.co.kr">
+<div class="main-header__inner">
+ <!-- header 상단 기본 -->
+ <div class="main-header__top">
+  <div class="navi_cont">
+   <!-- 20230411 클래스명 변경 -->
+   <div class="main-header__logo">
+    <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+   </div>
+   <div class="main-header__util-item" id="gnb_login">
+    <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+    <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+   </div>
+   <div class="main-header__family-site family-list">
+    <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+   </div>
+  </div>
+ </div><!-- // header 상단 기본 --> <!-- GNB 기본 -->
+ <div class="main-header__bottom">
+  <div class="navi_cont">
+   <!-- 20230411 클래스명 변경 -->
+   <div class="main-header__menu gnb">
+    <!-- 활성화된 메뉴의 a 태그에 is-active -->
+    <div class="gnb__item">
+     <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+    </div>
+    <div class="gnb__item">
+     <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+    </div>
+    <div class="gnb__item">
+     <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+    </div>
+    <div class="gnb__item">
+     <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+    </div>
+    <div class="gnb__item">
+     <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+    </div>
+   </div>
+   <div class="main-header__util header-util">
+    <div class="header-util__item">
+     <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+    </div>
+   </div>
+  </div>
+ </div><!-- // GNB 기본 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T membership main --> <!-- 혜택 브랜드 --> <!-- 20230414 2depth 삭제 --> <!-- GNB 서브페이지 (상품서비스) -->
+ <div class="main-header__lnb" style="display: none;">
+  <div class="navi_cont">
+   <div class="main-header__menu header-lnb">
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+    </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+   </div>
+  </div>
+ </div><!-- // GNB 서브페이지 (my) --> <!-- //20230414 2depth 삭제 --> <!-- //혜택 브랜드 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 혜택 프로그램 --> <!-- GNB Family menu -->
+ <div class="main-header__lnb" style="display: none;">
+  <div class="navi_cont">
+   <!-- 20230411 클래스명 변경 -->
+   <div class="main-header__menu header-lnb">
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+    </div>
+   </div>
+  </div>
+ </div><!-- // GNB Family menu --> <!-- //혜택 프로그램 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- 나의 T 멤버십 --> <!-- GNB Family menu -->
+ <div class="main-header__lnb" style="display: none;">
+  <div class="navi_cont">
+   <!-- 20230411 클래스명 변경 -->
+   <div class="main-header__menu header-lnb">
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+    </div>
+   </div>
+  </div>
+ </div><!-- // GNB Family menu --> <!-- //나의 T 멤버십 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> --> <!-- T 멤버십 안내 --> <!-- GNB Family menu -->
+ <div class="main-header__lnb" style="display: none;">
+  <div class="navi_cont">
+   <!-- 20230411 클래스명 변경 -->
+   <div class="main-header__menu header-lnb">
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+    </div>
+    <div class="header-lnb__item">
+     <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+    </div>
+   </div>
+  </div>
+ </div><!-- // GNB Family menu --> <!-- //T 멤버십 안내 --> <!-- 				<hr style="background: #808080;height: 50px;position: relative;text-indent: 0;left: 0;"> -->
+</div>
+<div class="main-header__top">
+ <div class="navi_cont">
+  <!-- 20230411 클래스명 변경 -->
+  <div class="main-header__logo">
+   <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+  </div>
+  <div class="main-header__util-item" id="gnb_login">
+   <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+   <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+  </div>
+  <div class="main-header__family-site family-list">
+   <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+  </div>
+ </div>
+</div>
+<div class="navi_cont">
+ <!-- 20230411 클래스명 변경 -->
+ <div class="main-header__logo">
+  <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+ </div>
+ <div class="main-header__util-item" id="gnb_login">
+  <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+  <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+ </div>
+ <div class="main-header__family-site family-list">
+  <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+ </div>
+</div>
+<div class="main-header__logo">
+ <a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+</div>
+<a href="https://www.tworld.co.kr" class="logo-tworld"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world"></a>
+<img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/new/logo_tworld.png" alt="T world">
+<div class="main-header__util-item" id="gnb_login">
+ <a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a><!-- 2023-05-30 수정 띄어쓰기 --> <a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a> <a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a><!-- 2023-05-30 수정 띄어쓰기 -->
+ <script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+</div>
+<a href="https://www.tworld.co.kr/web/search/total-search" class="icon icon-search"><span>T world 통합 검색</span></a>
+<span>T world 통합 검색</span>
+<a href="javascript:$common.gotoLogin();" class="icon icon-login"><span>로그인</span></a>
+<span>로그인</span>
+<a href="https://www.tworld.co.kr/web/login/tid-join" class="icon icon-register"><span>SK텔레콤 T 아이디 회원가입</span></a>
+<span>SK텔레콤 T 아이디 회원가입</span>
+<script type="text/javascript">
+							        function getCookie(cookieName) {
+							            try{
+							                var result = "";
+							                var allCookies = document.cookie.split("; ");
+							                var cookieArray = null;
+							                for (var i=0; i<allCookies.length; i++) {
+							                    cookieArray = allCookies[i].split("=");
+							                    if (cookieName == cookieArray[0]) {
+							                        result = cookieArray[1];
+							                        break;
+							                    }
+							                }
+							                return result;
+							            }catch(e){
+							                return ;
+							            }
+							        } 
+							    
+							        function setUserId() {
+							            var userId = getCookie("FILLID");
+							            if (typeof userId != 'undefined' && userId != "") {
+							                document.getElementById("ID").value = userId;
+							                document.getElementById("SaveInd").checked = true;
+							                document.getElementById("PASSWORD").focus();
+							            } else {
+							                document.getElementById("ID").focus();
+							            }
+							        }
+							    
+							        function isLogin(){
+							            try{
+							                var cookieNm = getCookie("pocstatus");
+							                //alert("cookieNm : "+cookieNm);
+							                if(cookieNm != null && cookieNm != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return true;
+							            }
+							        }
+							    
+							        function isSSOLogin(){
+							            try{
+							                var pocCookie = getCookie("pocsite");
+							                //alert("pocCookie : "+pocCookie);
+							                if(pocCookie !=  null && pocCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							    
+							        // 통합ID SSO Check
+							        function isSSOCheck(){
+							            try{
+							                var tidCookie = getCookie("SKTSSO");
+							                //alert("tidCookie : "+tidCookie);
+							                if(tidCookie !=  null && tidCookie != ""){
+							                    return true;
+							                }
+							                return false;
+							            }catch(e){
+							                return false;
+							            }
+							        }
+							        
+							        var tidCookie = getCookie("SKTSSO");
+							        if(tidCookie !=  null && tidCookie != ""){
+							            // tworld에서 로그인하고, 멤버십 랜덤하게 아무 사이트 진입시 SKTSSO연동
+							            $common.gotoLogin(null, 'N');
+							        }
+							    </script>
+<div class="main-header__family-site family-list">
+ <a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a> <a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+</div>
+<a href="https://sktuniverse.tworld.co.kr" class="icon icon-universe"><span class="hidden">T 우주</span></a>
+<span class="hidden">T 우주</span>
+<a href="https://troaming.tworld.co.kr" class="icon icon-roaming"><span class="hidden">T roaming</span></a>
+<span class="hidden">T roaming</span>
+<div class="main-header__bottom">
+ <div class="navi_cont">
+  <!-- 20230411 클래스명 변경 -->
+  <div class="main-header__menu gnb">
+   <!-- 활성화된 메뉴의 a 태그에 is-active -->
+   <div class="gnb__item">
+    <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+   </div>
+   <div class="gnb__item">
+    <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+   </div>
+   <div class="gnb__item">
+    <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+   </div>
+   <div class="gnb__item">
+    <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+   </div>
+   <div class="gnb__item">
+    <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+   </div>
+  </div>
+  <div class="main-header__util header-util">
+   <div class="header-util__item">
+    <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="navi_cont">
+ <!-- 20230411 클래스명 변경 -->
+ <div class="main-header__menu gnb">
+  <!-- 활성화된 메뉴의 a 태그에 is-active -->
+  <div class="gnb__item">
+   <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+  </div>
+  <div class="gnb__item">
+   <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+  </div>
+  <div class="gnb__item">
+   <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+  </div>
+  <div class="gnb__item">
+   <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+  </div>
+  <div class="gnb__item">
+   <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+  </div>
+ </div>
+ <div class="main-header__util header-util">
+  <div class="header-util__item">
+   <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+  </div>
+ </div>
+</div>
+<div class="main-header__menu gnb">
+ <!-- 활성화된 메뉴의 a 태그에 is-active -->
+ <div class="gnb__item">
+  <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+ </div>
+ <div class="gnb__item">
+  <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+ </div>
+ <div class="gnb__item">
+  <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+ </div>
+ <div class="gnb__item">
+  <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+ </div>
+ <div class="gnb__item">
+  <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+ </div>
+</div>
+<div class="gnb__item">
+ <a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+</div>
+<a href="javascript:;" ucode="u0" class="logo-tmembership"><img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership"></a>
+<img src="https://cdn.sktmembership.co.kr/mps.pc/resources/img/common/logo_tmembership.png" alt="T membership">
+<div class="gnb__item">
+ <a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+</div>
+<a href="javascript:;" ucode="u1_2" class="gnb__link">혜택 브랜드</a>
+<div class="gnb__item">
+ <a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+</div>
+<a href="javascript:;" ucode="u1_3" class="gnb__link">혜택 프로그램</a>
+<div class="gnb__item">
+ <a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+</div>
+<a href="javascript:;" ucode="u1_4" class="gnb__link">나의 T 멤버십</a>
+<div class="gnb__item">
+ <a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+</div>
+<a href="javascript:;" ucode="u1_5" class="gnb__link">T 멤버십 안내</a>
+<div class="main-header__util header-util">
+ <div class="header-util__item">
+  <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+ </div>
+</div>
+<div class="header-util__item">
+ <a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+</div>
+<a href="/mps/pc-bff/sktmembership/allView.do"><button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button></a>
+<button class="icon icon-hamburger"><span class="hidden">전체메뉴</span></button>
+<span class="hidden">전체메뉴</span>
+<div class="main-header__lnb" style="display: none;">
+ <div class="navi_cont">
+  <div class="main-header__menu header-lnb">
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+   </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+  </div>
+ </div>
+</div>
+<div class="navi_cont">
+ <div class="main-header__menu header-lnb">
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+  </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+ </div>
+</div>
+<div class="main-header__menu header-lnb">
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+ </div><!-- 
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									EAT<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link is-active">베이커리</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub is-active">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">외식</a>
+										<div class="lnb-sub__item-sub">
+											<a href="#" class="lnb-sub__link-sub">4 depth1</a>
+											<a href="#" class="lnb-sub__link-sub">4 depth2</a>
+										</div>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">카페&아이스크림</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">피자&치킨</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									BUY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">금융&통신</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">렌탈</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">쇼핑몰</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">패션&뷰티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">편의점</a>
+									</div>
+								</div>
+							</div>
+
+							<div class="header-lnb__item" data-element="commonToggle">
+								<a href="#" class="header-lnb__link" data-element="commonToggle__button">
+									PLAY<i class="header-lnb__arrow"></i>
+								</a>
+								<div class="header-lnb__layer lnb-sub" data-element="commonToggle__layer">
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">교육</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">액티비티</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">여행</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">영화</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">콘텐츠</a>
+									</div>
+									<div class="lnb-sub__item">
+										<a href="#" class="lnb-sub__link">테마파크</a>
+									</div>
+								</div>
+							</div>
+				-->
+</div>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+</div>
+<a href="javascript:;" ucode="u1_2_1" class="header-lnb__link">전체보기</a>
+<div class="main-header__lnb" style="display: none;">
+ <div class="navi_cont">
+  <!-- 20230411 클래스명 변경 -->
+  <div class="main-header__menu header-lnb">
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="navi_cont">
+ <!-- 20230411 클래스명 변경 -->
+ <div class="main-header__menu header-lnb">
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+  </div>
+ </div>
+</div>
+<div class="main-header__menu header-lnb">
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+ </div>
+</div>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+</div>
+<a href="javascript:;" ucode="u1_3_1" class="header-lnb__link">T day</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+</div>
+<a href="javascript:;" ucode="u1_3_2" class="header-lnb__link">VIP Pick</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+</div>
+<a href="javascript:;" ucode="u1_3_3" class="header-lnb__link">무비</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+</div>
+<a href="javascript:;" ucode="u1_3_4" class="header-lnb__link">글로벌/국내여행</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+</div>
+<a href="javascript:;" ucode="u1_3_5" class="header-lnb__link">열린멤버십</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+</div>
+<a href="javascript:;" ucode="u1_3_6" class="header-lnb__link">제휴</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+</div>
+<a href="javascript:;" ucode="u1_3_7" class="header-lnb__link">기프티콘</a>
+<div class="main-header__lnb" style="display: none;">
+ <div class="navi_cont">
+  <!-- 20230411 클래스명 변경 -->
+  <div class="main-header__menu header-lnb">
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="navi_cont">
+ <!-- 20230411 클래스명 변경 -->
+ <div class="main-header__menu header-lnb">
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+  </div>
+ </div>
+</div>
+<div class="main-header__menu header-lnb">
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+ </div>
+</div>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+</div>
+<a href="javascript:;" ucode="u1_4_1" class="header-lnb__link">회원정보</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+</div>
+<a href="javascript:;" ucode="u1_4_2" class="header-lnb__link">이용내역</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+</div>
+<a href="javascript:;" ucode="u1_4_3" class="header-lnb__link">T 멤버십 카드 신청/변경</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+</div>
+<a href="javascript:;" ucode="u1_4_4" class="header-lnb__link">고객센터 카드신청 약관동의</a>
+<div class="main-header__lnb" style="display: none;">
+ <div class="navi_cont">
+  <!-- 20230411 클래스명 변경 -->
+  <div class="main-header__menu header-lnb">
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+   </div>
+   <div class="header-lnb__item">
+    <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="navi_cont">
+ <!-- 20230411 클래스명 변경 -->
+ <div class="main-header__menu header-lnb">
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+  </div>
+  <div class="header-lnb__item">
+   <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+  </div>
+ </div>
+</div>
+<div class="main-header__menu header-lnb">
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+ </div>
+ <div class="header-lnb__item">
+  <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+ </div>
+</div>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+</div>
+<a href="javascript:;" ucode="u1_5_1" class="header-lnb__link">이용안내</a>
+<div class="header-lnb__item">
+ <a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+</div>
+<a href="javascript:;" ucode="u1_5_2" class="header-lnb__link">등급안내</a>
+<div class="header-lnb__item">
+ <a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+</div>
+<a href="https://www.tworld.co.kr/web/support/notice/tmembership" ucode="u1_5_3" class="header-lnb__link">공지사항</a>
+<div class="header-lnb__item">
+ <a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+</div>
+<a href="https://www.tworld.co.kr/web/support/faq/category?faqGrpCd1Depth=1500000" ucode="u1_5_4" class="header-lnb__link">FAQ</a>
+<div class="container">
+ <div id="content">
+  <div class="inr-wrap">
+   <div class="title-area">
+    <h1>파리바게뜨</h1><input type="hidden" name="brandId" id="brandId" value="1053"> <input type="hidden" name="brandName" id="brandName" value="파리바게뜨">
+   </div><!-- 브랜드 상단 영역 -->
+   <div class="brnad-info-top">
+    <div class="bit-left">
+     <p class="tit">대한민국 베이커리 문화를 선도하는 건강한 베이커리</p>
+     <div class="badge-list">
+      <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+     </div>
+    </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635235481847.png" alt="파리바게뜨"> </span>
+   </div><!-- //브랜드 상단 영역 --> <!-- 브랜드 선택 영역 -->
+   <div class="brand-sel-box">
+    <div class="fc-select">
+     <span>고객님이 선택하신 브랜드는</span>
+     <div class="dropdown" data-selectbox>
+      <a href="javascript:;" data-set-button> <span></span></a>
+      <div data-set-list>
+       <ul id="sel-ul">
+        <!-- 선택된 값에 'data-selected' 추가 -->
+        <li id="53" data-selected="data-selected"><a>베이커리</a></li>
+        <li id="54"><a>외식</a></li>
+        <li id="55"><a>카페/아이스크림</a></li>
+        <li id="56"><a>피자/치킨</a></li>
+        <li id="48"><a>금융/통신</a></li>
+        <li id="112"><a>렌탈</a></li>
+        <li id="116"><a>반려동물</a></li>
+        <li id="49"><a>생활/교통</a></li>
+        <li id="50"><a>쇼핑몰</a></li>
+        <li id="51"><a>패션/뷰티</a></li>
+        <li id="52"><a>편의점</a></li>
+        <li id="57"><a>교육</a></li>
+        <li id="109"><a>액티비티</a></li>
+        <li id="59"><a>여행</a></li>
+        <li id="60"><a>영화/공연/전시</a></li>
+        <li id="61"><a>콘텐츠</a></li>
+        <li id="110"><a>테마파크</a></li>
+       </ul>
+      </div>
+     </div>
+     <div class="dropdown" data-selectbox>
+      <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+      <div id="smallList" data-set-list>
+       <ul id="sel-list">
+        <li id="1053" data-selected="data-selected"><a>파리바게뜨</a></li>
+        <li id="1084"><a>뚜레쥬르</a></li>
+        <li id="1121"><a>파리크라상</a></li>
+        <li id="1151"><a>빌리엔젤</a></li>
+        <li id="1097"><a>열린베이커리</a></li>
+       </ul>
+      </div>
+     </div><span>입니다.</span>
+    </div>
+   </div><!-- //브랜드 선택 영역 --> <!-- 브랜드 상세 혜택 소개 영역 -->
+   <div class="brand-detail">
+    <div class="bd-top">
+     <div class="cate">
+      <span>EAT </span> <span>베이커리</span> <input type="hidden" name="categoryMid" id="categoryMid" value="53"> <input type="hidden" name="categoryMname" id="categoryMname" value="베이커리">
+     </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">127094</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="127094"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+    </div>
+    <div class="detail-list">
+     <dl>
+      <dt>
+       혜택
+      </dt>
+      <dd>
+       <dl class="dl-bnf">
+        <dt>
+         할인형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+         </div>
+        </dd>
+       </dl>
+       <dl class="dl-bnf">
+        <dt>
+         적립형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+         </div>
+        </dd>
+       </dl>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       유의사항
+      </dt>
+      <dd>
+       <div class="notice">
+        <div class="explain-area pd-no">
+         <ul class="list-dot">
+          <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+          <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+          <li>횟수 제한 : 1일 1회 결제금액 1천 원 이상 시 할인 또는 적립 가능</li>
+          <li>최대 할인 가능 : 플라스틱 카드 이용 시 일 최대 10,000원 할인</li>
+          <li>최대 할인 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000원, SILVER 10,000원 할인</li>
+          <li>최대 적립 가능 : 플라스틱 카드 이용 시 일 최대 10,000P 적립</li>
+          <li>최대 적립 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000P, SILVER 10,000P 적립</li>
+          <li>결제 전 직원에게 T 멤버십 카드 제시</li>
+          <li>타 적립 및 쿠폰 동시 적용 불가</li>
+          <li>제외 매장 : 일부 점포(휴게소, 역사, 인샵, 특수매장 등) 제외 됩니다.</li>
+          <li>적립된 포인트는 ‘적립 예정’ 포인트로 표시되며, 결제일 1일 이후부터 사용 가능 포인트로 전환됩니다.</li>
+         </ul>
+        </div>
+       </div>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       문의 및 상담
+      </dt>
+      <dd>
+       <ul class="list-dash">
+        <li>TEL : 080-731-2027</li>
+        <li>HOME : <a href="javascript:goHomePage('https://www.paris.co.kr/')">https://www.paris.co.kr/</a></li>
+       </ul>
+      </dd>
+     </dl>
+    </div>
+   </div>
+  </div><!-- //브랜드 상세 혜택 소개 영역 --> <!-- 비슷한 혜택 브랜드 추천 영역 -->
+  <div class="similar-area">
+   <div class="inr-wrap">
+    <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+    <ul class="benefit-list">
+     <li><a href="javascript:;" class="benefit-box" id="1121" data-title="파리크라상" data-idx="0" data-cate-id="53" data-cate-name="베이커리">
+       <div class="bnf-top">
+        <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635236220043.png" alt="파리크라상"> </span> <span class="sort">베이커리</span> <span class="brand">파리크라상</span>
+        <div class="badge-list">
+         <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+        </div>
+       </div>
+       <div class="bnf-info">
+        <dl class="dl-bnf">
+         <dt>
+          할인형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+          </div>
+         </dd>
+        </dl>
+        <dl class="dl-bnf">
+         <dt>
+          적립형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+          </div>
+         </dd>
+        </dl>
+       </div><span class="btn-round gra">자세히 보기</span> </a></li>
+     <li><a href="javascript:;" class="benefit-box" id="1151" data-title="빌리엔젤" data-idx="1" data-cate-id="53" data-cate-name="베이커리">
+       <div class="bnf-top">
+        <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202209/1663893303634.png" alt="빌리엔젤"> </span> <span class="sort">베이커리</span> <span class="brand">빌리엔젤</span>
+        <div class="badge-list">
+         <i class="badge-bg-radius skyBlue">할인</i>
+        </div>
+       </div>
+       <div class="bnf-info">
+        <dl class="dl-bnf">
+         <dt>
+          할인형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+          </div>
+         </dd>
+        </dl>
+        <dl class="dl-bnf">
+         <dt>
+          적립형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+          </div>
+         </dd>
+        </dl>
+       </div><span class="btn-round gra">자세히 보기</span> </a></li>
+     <li><a href="javascript:;" class="benefit-box" id="1084" data-title="뚜레쥬르" data-idx="2" data-cate-id="53" data-cate-name="베이커리">
+       <div class="bnf-top">
+        <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635148435539.png" alt="뚜레쥬르"> </span> <span class="sort">베이커리</span> <span class="brand">뚜레쥬르</span>
+        <div class="badge-list">
+         <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+        </div>
+       </div>
+       <div class="bnf-info">
+        <dl class="dl-bnf">
+         <dt>
+          할인형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150원 할인
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50원 할인
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+          </div>
+         </dd>
+        </dl>
+        <dl class="dl-bnf">
+         <dt>
+          적립형
+         </dt>
+         <dd>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150P 적립
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50P 적립
+          </div>
+          <div class="info">
+           <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+          </div>
+         </dd>
+        </dl>
+       </div><span class="btn-round gra">자세히 보기</span> </a></li>
+    </ul>
+   </div>
+  </div><!-- //비슷한 혜택 브랜드 추천 영역 -->
+ </div>
+</div>
+<div id="content">
+ <div class="inr-wrap">
+  <div class="title-area">
+   <h1>파리바게뜨</h1><input type="hidden" name="brandId" id="brandId" value="1053"> <input type="hidden" name="brandName" id="brandName" value="파리바게뜨">
+  </div><!-- 브랜드 상단 영역 -->
+  <div class="brnad-info-top">
+   <div class="bit-left">
+    <p class="tit">대한민국 베이커리 문화를 선도하는 건강한 베이커리</p>
+    <div class="badge-list">
+     <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+    </div>
+   </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635235481847.png" alt="파리바게뜨"> </span>
+  </div><!-- //브랜드 상단 영역 --> <!-- 브랜드 선택 영역 -->
+  <div class="brand-sel-box">
+   <div class="fc-select">
+    <span>고객님이 선택하신 브랜드는</span>
+    <div class="dropdown" data-selectbox>
+     <a href="javascript:;" data-set-button> <span></span></a>
+     <div data-set-list>
+      <ul id="sel-ul">
+       <!-- 선택된 값에 'data-selected' 추가 -->
+       <li id="53" data-selected="data-selected"><a>베이커리</a></li>
+       <li id="54"><a>외식</a></li>
+       <li id="55"><a>카페/아이스크림</a></li>
+       <li id="56"><a>피자/치킨</a></li>
+       <li id="48"><a>금융/통신</a></li>
+       <li id="112"><a>렌탈</a></li>
+       <li id="116"><a>반려동물</a></li>
+       <li id="49"><a>생활/교통</a></li>
+       <li id="50"><a>쇼핑몰</a></li>
+       <li id="51"><a>패션/뷰티</a></li>
+       <li id="52"><a>편의점</a></li>
+       <li id="57"><a>교육</a></li>
+       <li id="109"><a>액티비티</a></li>
+       <li id="59"><a>여행</a></li>
+       <li id="60"><a>영화/공연/전시</a></li>
+       <li id="61"><a>콘텐츠</a></li>
+       <li id="110"><a>테마파크</a></li>
+      </ul>
+     </div>
+    </div>
+    <div class="dropdown" data-selectbox>
+     <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+     <div id="smallList" data-set-list>
+      <ul id="sel-list">
+       <li id="1053" data-selected="data-selected"><a>파리바게뜨</a></li>
+       <li id="1084"><a>뚜레쥬르</a></li>
+       <li id="1121"><a>파리크라상</a></li>
+       <li id="1151"><a>빌리엔젤</a></li>
+       <li id="1097"><a>열린베이커리</a></li>
+      </ul>
+     </div>
+    </div><span>입니다.</span>
+   </div>
+  </div><!-- //브랜드 선택 영역 --> <!-- 브랜드 상세 혜택 소개 영역 -->
+  <div class="brand-detail">
+   <div class="bd-top">
+    <div class="cate">
+     <span>EAT </span> <span>베이커리</span> <input type="hidden" name="categoryMid" id="categoryMid" value="53"> <input type="hidden" name="categoryMname" id="categoryMname" value="베이커리">
+    </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">127094</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="127094"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+   </div>
+   <div class="detail-list">
+    <dl>
+     <dt>
+      혜택
+     </dt>
+     <dd>
+      <dl class="dl-bnf">
+       <dt>
+        할인형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+        </div>
+       </dd>
+      </dl>
+      <dl class="dl-bnf">
+       <dt>
+        적립형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+        </div>
+       </dd>
+      </dl>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      유의사항
+     </dt>
+     <dd>
+      <div class="notice">
+       <div class="explain-area pd-no">
+        <ul class="list-dot">
+         <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+         <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+         <li>횟수 제한 : 1일 1회 결제금액 1천 원 이상 시 할인 또는 적립 가능</li>
+         <li>최대 할인 가능 : 플라스틱 카드 이용 시 일 최대 10,000원 할인</li>
+         <li>최대 할인 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000원, SILVER 10,000원 할인</li>
+         <li>최대 적립 가능 : 플라스틱 카드 이용 시 일 최대 10,000P 적립</li>
+         <li>최대 적립 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000P, SILVER 10,000P 적립</li>
+         <li>결제 전 직원에게 T 멤버십 카드 제시</li>
+         <li>타 적립 및 쿠폰 동시 적용 불가</li>
+         <li>제외 매장 : 일부 점포(휴게소, 역사, 인샵, 특수매장 등) 제외 됩니다.</li>
+         <li>적립된 포인트는 ‘적립 예정’ 포인트로 표시되며, 결제일 1일 이후부터 사용 가능 포인트로 전환됩니다.</li>
+        </ul>
+       </div>
+      </div>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      문의 및 상담
+     </dt>
+     <dd>
+      <ul class="list-dash">
+       <li>TEL : 080-731-2027</li>
+       <li>HOME : <a href="javascript:goHomePage('https://www.paris.co.kr/')">https://www.paris.co.kr/</a></li>
+      </ul>
+     </dd>
+    </dl>
+   </div>
+  </div>
+ </div><!-- //브랜드 상세 혜택 소개 영역 --> <!-- 비슷한 혜택 브랜드 추천 영역 -->
+ <div class="similar-area">
+  <div class="inr-wrap">
+   <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+   <ul class="benefit-list">
+    <li><a href="javascript:;" class="benefit-box" id="1121" data-title="파리크라상" data-idx="0" data-cate-id="53" data-cate-name="베이커리">
+      <div class="bnf-top">
+       <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635236220043.png" alt="파리크라상"> </span> <span class="sort">베이커리</span> <span class="brand">파리크라상</span>
+       <div class="badge-list">
+        <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+       </div>
+      </div>
+      <div class="bnf-info">
+       <dl class="dl-bnf">
+        <dt>
+         할인형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+         </div>
+        </dd>
+       </dl>
+       <dl class="dl-bnf">
+        <dt>
+         적립형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+         </div>
+        </dd>
+       </dl>
+      </div><span class="btn-round gra">자세히 보기</span> </a></li>
+    <li><a href="javascript:;" class="benefit-box" id="1151" data-title="빌리엔젤" data-idx="1" data-cate-id="53" data-cate-name="베이커리">
+      <div class="bnf-top">
+       <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202209/1663893303634.png" alt="빌리엔젤"> </span> <span class="sort">베이커리</span> <span class="brand">빌리엔젤</span>
+       <div class="badge-list">
+        <i class="badge-bg-radius skyBlue">할인</i>
+       </div>
+      </div>
+      <div class="bnf-info">
+       <dl class="dl-bnf">
+        <dt>
+         할인형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+         </div>
+        </dd>
+       </dl>
+       <dl class="dl-bnf">
+        <dt>
+         적립형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+         </div>
+        </dd>
+       </dl>
+      </div><span class="btn-round gra">자세히 보기</span> </a></li>
+    <li><a href="javascript:;" class="benefit-box" id="1084" data-title="뚜레쥬르" data-idx="2" data-cate-id="53" data-cate-name="베이커리">
+      <div class="bnf-top">
+       <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635148435539.png" alt="뚜레쥬르"> </span> <span class="sort">베이커리</span> <span class="brand">뚜레쥬르</span>
+       <div class="badge-list">
+        <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+       </div>
+      </div>
+      <div class="bnf-info">
+       <dl class="dl-bnf">
+        <dt>
+         할인형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150원 할인
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50원 할인
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+         </div>
+        </dd>
+       </dl>
+       <dl class="dl-bnf">
+        <dt>
+         적립형
+        </dt>
+        <dd>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150P 적립
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50P 적립
+         </div>
+         <div class="info">
+          <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+         </div>
+        </dd>
+       </dl>
+      </div><span class="btn-round gra">자세히 보기</span> </a></li>
+   </ul>
+  </div>
+ </div><!-- //비슷한 혜택 브랜드 추천 영역 -->
+</div>
+<div class="inr-wrap">
+ <div class="title-area">
+  <h1>파리바게뜨</h1><input type="hidden" name="brandId" id="brandId" value="1053"> <input type="hidden" name="brandName" id="brandName" value="파리바게뜨">
+ </div><!-- 브랜드 상단 영역 -->
+ <div class="brnad-info-top">
+  <div class="bit-left">
+   <p class="tit">대한민국 베이커리 문화를 선도하는 건강한 베이커리</p>
+   <div class="badge-list">
+    <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+   </div>
+  </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635235481847.png" alt="파리바게뜨"> </span>
+ </div><!-- //브랜드 상단 영역 --> <!-- 브랜드 선택 영역 -->
+ <div class="brand-sel-box">
+  <div class="fc-select">
+   <span>고객님이 선택하신 브랜드는</span>
+   <div class="dropdown" data-selectbox>
+    <a href="javascript:;" data-set-button> <span></span></a>
+    <div data-set-list>
+     <ul id="sel-ul">
+      <!-- 선택된 값에 'data-selected' 추가 -->
+      <li id="53" data-selected="data-selected"><a>베이커리</a></li>
+      <li id="54"><a>외식</a></li>
+      <li id="55"><a>카페/아이스크림</a></li>
+      <li id="56"><a>피자/치킨</a></li>
+      <li id="48"><a>금융/통신</a></li>
+      <li id="112"><a>렌탈</a></li>
+      <li id="116"><a>반려동물</a></li>
+      <li id="49"><a>생활/교통</a></li>
+      <li id="50"><a>쇼핑몰</a></li>
+      <li id="51"><a>패션/뷰티</a></li>
+      <li id="52"><a>편의점</a></li>
+      <li id="57"><a>교육</a></li>
+      <li id="109"><a>액티비티</a></li>
+      <li id="59"><a>여행</a></li>
+      <li id="60"><a>영화/공연/전시</a></li>
+      <li id="61"><a>콘텐츠</a></li>
+      <li id="110"><a>테마파크</a></li>
+     </ul>
+    </div>
+   </div>
+   <div class="dropdown" data-selectbox>
+    <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+    <div id="smallList" data-set-list>
+     <ul id="sel-list">
+      <li id="1053" data-selected="data-selected"><a>파리바게뜨</a></li>
+      <li id="1084"><a>뚜레쥬르</a></li>
+      <li id="1121"><a>파리크라상</a></li>
+      <li id="1151"><a>빌리엔젤</a></li>
+      <li id="1097"><a>열린베이커리</a></li>
+     </ul>
+    </div>
+   </div><span>입니다.</span>
+  </div>
+ </div><!-- //브랜드 선택 영역 --> <!-- 브랜드 상세 혜택 소개 영역 -->
+ <div class="brand-detail">
+  <div class="bd-top">
+   <div class="cate">
+    <span>EAT </span> <span>베이커리</span> <input type="hidden" name="categoryMid" id="categoryMid" value="53"> <input type="hidden" name="categoryMname" id="categoryMname" value="베이커리">
+   </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">127094</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="127094"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+  </div>
+  <div class="detail-list">
+   <dl>
+    <dt>
+     혜택
+    </dt>
+    <dd>
+     <dl class="dl-bnf">
+      <dt>
+       할인형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+       </div>
+      </dd>
+     </dl>
+     <dl class="dl-bnf">
+      <dt>
+       적립형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+       </div>
+      </dd>
+     </dl>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     유의사항
+    </dt>
+    <dd>
+     <div class="notice">
+      <div class="explain-area pd-no">
+       <ul class="list-dot">
+        <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+        <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+        <li>횟수 제한 : 1일 1회 결제금액 1천 원 이상 시 할인 또는 적립 가능</li>
+        <li>최대 할인 가능 : 플라스틱 카드 이용 시 일 최대 10,000원 할인</li>
+        <li>최대 할인 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000원, SILVER 10,000원 할인</li>
+        <li>최대 적립 가능 : 플라스틱 카드 이용 시 일 최대 10,000P 적립</li>
+        <li>최대 적립 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000P, SILVER 10,000P 적립</li>
+        <li>결제 전 직원에게 T 멤버십 카드 제시</li>
+        <li>타 적립 및 쿠폰 동시 적용 불가</li>
+        <li>제외 매장 : 일부 점포(휴게소, 역사, 인샵, 특수매장 등) 제외 됩니다.</li>
+        <li>적립된 포인트는 ‘적립 예정’ 포인트로 표시되며, 결제일 1일 이후부터 사용 가능 포인트로 전환됩니다.</li>
+       </ul>
+      </div>
+     </div>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     문의 및 상담
+    </dt>
+    <dd>
+     <ul class="list-dash">
+      <li>TEL : 080-731-2027</li>
+      <li>HOME : <a href="javascript:goHomePage('https://www.paris.co.kr/')">https://www.paris.co.kr/</a></li>
+     </ul>
+    </dd>
+   </dl>
+  </div>
+ </div>
+</div>
+<div class="title-area">
+ <h1>파리바게뜨</h1><input type="hidden" name="brandId" id="brandId" value="1053"> <input type="hidden" name="brandName" id="brandName" value="파리바게뜨">
+</div>
+<h1>파리바게뜨</h1>
+<input type="hidden" name="brandId" id="brandId" value="1053">
+<input type="hidden" name="brandName" id="brandName" value="파리바게뜨">
+<div class="brnad-info-top">
+ <div class="bit-left">
+  <p class="tit">대한민국 베이커리 문화를 선도하는 건강한 베이커리</p>
+  <div class="badge-list">
+   <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+  </div>
+ </div><span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635235481847.png" alt="파리바게뜨"> </span>
+</div>
+<div class="bit-left">
+ <p class="tit">대한민국 베이커리 문화를 선도하는 건강한 베이커리</p>
+ <div class="badge-list">
+  <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+ </div>
+</div>
+<p class="tit">대한민국 베이커리 문화를 선도하는 건강한 베이커리</p>
+<div class="badge-list">
+ <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+</div>
+<i class="badge-bg-radius skyBlue">할인</i>
+<i class="badge-bg-radius pink">적립</i>
+<i class="badge-bg-radius skyBlue">사용</i>
+<span class="brand-logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635235481847.png" alt="파리바게뜨"> </span>
+<img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635235481847.png" alt="파리바게뜨">
+<div class="brand-sel-box">
+ <div class="fc-select">
+  <span>고객님이 선택하신 브랜드는</span>
+  <div class="dropdown" data-selectbox>
+   <a href="javascript:;" data-set-button> <span></span></a>
+   <div data-set-list>
+    <ul id="sel-ul">
+     <!-- 선택된 값에 'data-selected' 추가 -->
+     <li id="53" data-selected="data-selected"><a>베이커리</a></li>
+     <li id="54"><a>외식</a></li>
+     <li id="55"><a>카페/아이스크림</a></li>
+     <li id="56"><a>피자/치킨</a></li>
+     <li id="48"><a>금융/통신</a></li>
+     <li id="112"><a>렌탈</a></li>
+     <li id="116"><a>반려동물</a></li>
+     <li id="49"><a>생활/교통</a></li>
+     <li id="50"><a>쇼핑몰</a></li>
+     <li id="51"><a>패션/뷰티</a></li>
+     <li id="52"><a>편의점</a></li>
+     <li id="57"><a>교육</a></li>
+     <li id="109"><a>액티비티</a></li>
+     <li id="59"><a>여행</a></li>
+     <li id="60"><a>영화/공연/전시</a></li>
+     <li id="61"><a>콘텐츠</a></li>
+     <li id="110"><a>테마파크</a></li>
+    </ul>
+   </div>
+  </div>
+  <div class="dropdown" data-selectbox>
+   <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+   <div id="smallList" data-set-list>
+    <ul id="sel-list">
+     <li id="1053" data-selected="data-selected"><a>파리바게뜨</a></li>
+     <li id="1084"><a>뚜레쥬르</a></li>
+     <li id="1121"><a>파리크라상</a></li>
+     <li id="1151"><a>빌리엔젤</a></li>
+     <li id="1097"><a>열린베이커리</a></li>
+    </ul>
+   </div>
+  </div><span>입니다.</span>
+ </div>
+</div>
+<div class="fc-select">
+ <span>고객님이 선택하신 브랜드는</span>
+ <div class="dropdown" data-selectbox>
+  <a href="javascript:;" data-set-button> <span></span></a>
+  <div data-set-list>
+   <ul id="sel-ul">
+    <!-- 선택된 값에 'data-selected' 추가 -->
+    <li id="53" data-selected="data-selected"><a>베이커리</a></li>
+    <li id="54"><a>외식</a></li>
+    <li id="55"><a>카페/아이스크림</a></li>
+    <li id="56"><a>피자/치킨</a></li>
+    <li id="48"><a>금융/통신</a></li>
+    <li id="112"><a>렌탈</a></li>
+    <li id="116"><a>반려동물</a></li>
+    <li id="49"><a>생활/교통</a></li>
+    <li id="50"><a>쇼핑몰</a></li>
+    <li id="51"><a>패션/뷰티</a></li>
+    <li id="52"><a>편의점</a></li>
+    <li id="57"><a>교육</a></li>
+    <li id="109"><a>액티비티</a></li>
+    <li id="59"><a>여행</a></li>
+    <li id="60"><a>영화/공연/전시</a></li>
+    <li id="61"><a>콘텐츠</a></li>
+    <li id="110"><a>테마파크</a></li>
+   </ul>
+  </div>
+ </div>
+ <div class="dropdown" data-selectbox>
+  <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+  <div id="smallList" data-set-list>
+   <ul id="sel-list">
+    <li id="1053" data-selected="data-selected"><a>파리바게뜨</a></li>
+    <li id="1084"><a>뚜레쥬르</a></li>
+    <li id="1121"><a>파리크라상</a></li>
+    <li id="1151"><a>빌리엔젤</a></li>
+    <li id="1097"><a>열린베이커리</a></li>
+   </ul>
+  </div>
+ </div><span>입니다.</span>
+</div>
+<span>고객님이 선택하신 브랜드는</span>
+<div class="dropdown" data-selectbox>
+ <a href="javascript:;" data-set-button> <span></span></a>
+ <div data-set-list>
+  <ul id="sel-ul">
+   <!-- 선택된 값에 'data-selected' 추가 -->
+   <li id="53" data-selected="data-selected"><a>베이커리</a></li>
+   <li id="54"><a>외식</a></li>
+   <li id="55"><a>카페/아이스크림</a></li>
+   <li id="56"><a>피자/치킨</a></li>
+   <li id="48"><a>금융/통신</a></li>
+   <li id="112"><a>렌탈</a></li>
+   <li id="116"><a>반려동물</a></li>
+   <li id="49"><a>생활/교통</a></li>
+   <li id="50"><a>쇼핑몰</a></li>
+   <li id="51"><a>패션/뷰티</a></li>
+   <li id="52"><a>편의점</a></li>
+   <li id="57"><a>교육</a></li>
+   <li id="109"><a>액티비티</a></li>
+   <li id="59"><a>여행</a></li>
+   <li id="60"><a>영화/공연/전시</a></li>
+   <li id="61"><a>콘텐츠</a></li>
+   <li id="110"><a>테마파크</a></li>
+  </ul>
+ </div>
+</div>
+<a href="javascript:;" data-set-button> <span></span></a>
+<span></span>
+<div data-set-list>
+ <ul id="sel-ul">
+  <!-- 선택된 값에 'data-selected' 추가 -->
+  <li id="53" data-selected="data-selected"><a>베이커리</a></li>
+  <li id="54"><a>외식</a></li>
+  <li id="55"><a>카페/아이스크림</a></li>
+  <li id="56"><a>피자/치킨</a></li>
+  <li id="48"><a>금융/통신</a></li>
+  <li id="112"><a>렌탈</a></li>
+  <li id="116"><a>반려동물</a></li>
+  <li id="49"><a>생활/교통</a></li>
+  <li id="50"><a>쇼핑몰</a></li>
+  <li id="51"><a>패션/뷰티</a></li>
+  <li id="52"><a>편의점</a></li>
+  <li id="57"><a>교육</a></li>
+  <li id="109"><a>액티비티</a></li>
+  <li id="59"><a>여행</a></li>
+  <li id="60"><a>영화/공연/전시</a></li>
+  <li id="61"><a>콘텐츠</a></li>
+  <li id="110"><a>테마파크</a></li>
+ </ul>
+</div>
+<ul id="sel-ul">
+ <!-- 선택된 값에 'data-selected' 추가 -->
+ <li id="53" data-selected="data-selected"><a>베이커리</a></li>
+ <li id="54"><a>외식</a></li>
+ <li id="55"><a>카페/아이스크림</a></li>
+ <li id="56"><a>피자/치킨</a></li>
+ <li id="48"><a>금융/통신</a></li>
+ <li id="112"><a>렌탈</a></li>
+ <li id="116"><a>반려동물</a></li>
+ <li id="49"><a>생활/교통</a></li>
+ <li id="50"><a>쇼핑몰</a></li>
+ <li id="51"><a>패션/뷰티</a></li>
+ <li id="52"><a>편의점</a></li>
+ <li id="57"><a>교육</a></li>
+ <li id="109"><a>액티비티</a></li>
+ <li id="59"><a>여행</a></li>
+ <li id="60"><a>영화/공연/전시</a></li>
+ <li id="61"><a>콘텐츠</a></li>
+ <li id="110"><a>테마파크</a></li>
+</ul>
+<li id="53" data-selected="data-selected"><a>베이커리</a></li>
+<a>베이커리</a>
+<li id="54"><a>외식</a></li>
+<a>외식</a>
+<li id="55"><a>카페/아이스크림</a></li>
+<a>카페/아이스크림</a>
+<li id="56"><a>피자/치킨</a></li>
+<a>피자/치킨</a>
+<li id="48"><a>금융/통신</a></li>
+<a>금융/통신</a>
+<li id="112"><a>렌탈</a></li>
+<a>렌탈</a>
+<li id="116"><a>반려동물</a></li>
+<a>반려동물</a>
+<li id="49"><a>생활/교통</a></li>
+<a>생활/교통</a>
+<li id="50"><a>쇼핑몰</a></li>
+<a>쇼핑몰</a>
+<li id="51"><a>패션/뷰티</a></li>
+<a>패션/뷰티</a>
+<li id="52"><a>편의점</a></li>
+<a>편의점</a>
+<li id="57"><a>교육</a></li>
+<a>교육</a>
+<li id="109"><a>액티비티</a></li>
+<a>액티비티</a>
+<li id="59"><a>여행</a></li>
+<a>여행</a>
+<li id="60"><a>영화/공연/전시</a></li>
+<a>영화/공연/전시</a>
+<li id="61"><a>콘텐츠</a></li>
+<a>콘텐츠</a>
+<li id="110"><a>테마파크</a></li>
+<a>테마파크</a>
+<div class="dropdown" data-selectbox>
+ <a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+ <div id="smallList" data-set-list>
+  <ul id="sel-list">
+   <li id="1053" data-selected="data-selected"><a>파리바게뜨</a></li>
+   <li id="1084"><a>뚜레쥬르</a></li>
+   <li id="1121"><a>파리크라상</a></li>
+   <li id="1151"><a>빌리엔젤</a></li>
+   <li id="1097"><a>열린베이커리</a></li>
+  </ul>
+ </div>
+</div>
+<a href="javascript:;" id="smallTitle" data-set-button> <span></span></a>
+<span></span>
+<div id="smallList" data-set-list>
+ <ul id="sel-list">
+  <li id="1053" data-selected="data-selected"><a>파리바게뜨</a></li>
+  <li id="1084"><a>뚜레쥬르</a></li>
+  <li id="1121"><a>파리크라상</a></li>
+  <li id="1151"><a>빌리엔젤</a></li>
+  <li id="1097"><a>열린베이커리</a></li>
+ </ul>
+</div>
+<ul id="sel-list">
+ <li id="1053" data-selected="data-selected"><a>파리바게뜨</a></li>
+ <li id="1084"><a>뚜레쥬르</a></li>
+ <li id="1121"><a>파리크라상</a></li>
+ <li id="1151"><a>빌리엔젤</a></li>
+ <li id="1097"><a>열린베이커리</a></li>
+</ul>
+<li id="1053" data-selected="data-selected"><a>파리바게뜨</a></li>
+<a>파리바게뜨</a>
+<li id="1084"><a>뚜레쥬르</a></li>
+<a>뚜레쥬르</a>
+<li id="1121"><a>파리크라상</a></li>
+<a>파리크라상</a>
+<li id="1151"><a>빌리엔젤</a></li>
+<a>빌리엔젤</a>
+<li id="1097"><a>열린베이커리</a></li>
+<a>열린베이커리</a>
+<span>입니다.</span>
+<div class="brand-detail">
+ <div class="bd-top">
+  <div class="cate">
+   <span>EAT </span> <span>베이커리</span> <input type="hidden" name="categoryMid" id="categoryMid" value="53"> <input type="hidden" name="categoryMname" id="categoryMname" value="베이커리">
+  </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">127094</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="127094"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+ </div>
+ <div class="detail-list">
+  <dl>
+   <dt>
+    혜택
+   </dt>
+   <dd>
+    <dl class="dl-bnf">
+     <dt>
+      할인형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+      </div>
+     </dd>
+    </dl>
+    <dl class="dl-bnf">
+     <dt>
+      적립형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+      </div>
+     </dd>
+    </dl>
+   </dd>
+  </dl>
+  <dl>
+   <dt>
+    유의사항
+   </dt>
+   <dd>
+    <div class="notice">
+     <div class="explain-area pd-no">
+      <ul class="list-dot">
+       <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+       <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+       <li>횟수 제한 : 1일 1회 결제금액 1천 원 이상 시 할인 또는 적립 가능</li>
+       <li>최대 할인 가능 : 플라스틱 카드 이용 시 일 최대 10,000원 할인</li>
+       <li>최대 할인 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000원, SILVER 10,000원 할인</li>
+       <li>최대 적립 가능 : 플라스틱 카드 이용 시 일 최대 10,000P 적립</li>
+       <li>최대 적립 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000P, SILVER 10,000P 적립</li>
+       <li>결제 전 직원에게 T 멤버십 카드 제시</li>
+       <li>타 적립 및 쿠폰 동시 적용 불가</li>
+       <li>제외 매장 : 일부 점포(휴게소, 역사, 인샵, 특수매장 등) 제외 됩니다.</li>
+       <li>적립된 포인트는 ‘적립 예정’ 포인트로 표시되며, 결제일 1일 이후부터 사용 가능 포인트로 전환됩니다.</li>
+      </ul>
+     </div>
+    </div>
+   </dd>
+  </dl>
+  <dl>
+   <dt>
+    문의 및 상담
+   </dt>
+   <dd>
+    <ul class="list-dash">
+     <li>TEL : 080-731-2027</li>
+     <li>HOME : <a href="javascript:goHomePage('https://www.paris.co.kr/')">https://www.paris.co.kr/</a></li>
+    </ul>
+   </dd>
+  </dl>
+ </div>
+</div>
+<div class="bd-top">
+ <div class="cate">
+  <span>EAT </span> <span>베이커리</span> <input type="hidden" name="categoryMid" id="categoryMid" value="53"> <input type="hidden" name="categoryMname" id="categoryMname" value="베이커리">
+ </div><button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">127094</span></button> <input type="hidden" name="favoriteCount" id="favoriteCount" value="127094"> <input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+</div>
+<div class="cate">
+ <span>EAT </span> <span>베이커리</span> <input type="hidden" name="categoryMid" id="categoryMid" value="53"> <input type="hidden" name="categoryMname" id="categoryMname" value="베이커리">
+</div>
+<span>EAT </span>
+<span>베이커리</span>
+<input type="hidden" name="categoryMid" id="categoryMid" value="53">
+<input type="hidden" name="categoryMname" id="categoryMname" value="베이커리">
+<button type="button" class="btn-heart"><i class="ico-heart"></i><span id="favoriteNewCount">127094</span></button>
+<i class="ico-heart"></i>
+<span id="favoriteNewCount">127094</span>
+<input type="hidden" name="favoriteCount" id="favoriteCount" value="127094">
+<input type="hidden" name="favoriteYn" id="favoriteYn" value="N">
+<div class="detail-list">
+ <dl>
+  <dt>
+   혜택
+  </dt>
+  <dd>
+   <dl class="dl-bnf">
+    <dt>
+     할인형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+     </div>
+    </dd>
+   </dl>
+   <dl class="dl-bnf">
+    <dt>
+     적립형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+     </div>
+    </dd>
+   </dl>
+  </dd>
+ </dl>
+ <dl>
+  <dt>
+   유의사항
+  </dt>
+  <dd>
+   <div class="notice">
+    <div class="explain-area pd-no">
+     <ul class="list-dot">
+      <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+      <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+      <li>횟수 제한 : 1일 1회 결제금액 1천 원 이상 시 할인 또는 적립 가능</li>
+      <li>최대 할인 가능 : 플라스틱 카드 이용 시 일 최대 10,000원 할인</li>
+      <li>최대 할인 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000원, SILVER 10,000원 할인</li>
+      <li>최대 적립 가능 : 플라스틱 카드 이용 시 일 최대 10,000P 적립</li>
+      <li>최대 적립 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000P, SILVER 10,000P 적립</li>
+      <li>결제 전 직원에게 T 멤버십 카드 제시</li>
+      <li>타 적립 및 쿠폰 동시 적용 불가</li>
+      <li>제외 매장 : 일부 점포(휴게소, 역사, 인샵, 특수매장 등) 제외 됩니다.</li>
+      <li>적립된 포인트는 ‘적립 예정’ 포인트로 표시되며, 결제일 1일 이후부터 사용 가능 포인트로 전환됩니다.</li>
+     </ul>
+    </div>
+   </div>
+  </dd>
+ </dl>
+ <dl>
+  <dt>
+   문의 및 상담
+  </dt>
+  <dd>
+   <ul class="list-dash">
+    <li>TEL : 080-731-2027</li>
+    <li>HOME : <a href="javascript:goHomePage('https://www.paris.co.kr/')">https://www.paris.co.kr/</a></li>
+   </ul>
+  </dd>
+ </dl>
+</div>
+<dl>
+ <dt>
+  혜택
+ </dt>
+ <dd>
+  <dl class="dl-bnf">
+   <dt>
+    할인형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+    </div>
+   </dd>
+  </dl>
+  <dl class="dl-bnf">
+   <dt>
+    적립형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+    </div>
+   </dd>
+  </dl>
+ </dd>
+</dl>
+<dt>
+ 혜택
+</dt>
+<dd>
+ <dl class="dl-bnf">
+  <dt>
+   할인형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+   </div>
+  </dd>
+ </dl>
+ <dl class="dl-bnf">
+  <dt>
+   적립형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+   </div>
+  </dd>
+ </dl>
+</dd>
+<dl class="dl-bnf">
+ <dt>
+  할인형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+  </div>
+ </dd>
+</dl>
+<dt>
+ 할인형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+</div>
+<span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<dl class="dl-bnf">
+ <dt>
+  적립형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+  </div>
+ </dd>
+</dl>
+<dt>
+ 적립형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+</div>
+<span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<i class="badge-circle lite"><span class="blind">L</span></i>
+<span class="blind">L</span>
+<dl>
+ <dt>
+  유의사항
+ </dt>
+ <dd>
+  <div class="notice">
+   <div class="explain-area pd-no">
+    <ul class="list-dot">
+     <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+     <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+     <li>횟수 제한 : 1일 1회 결제금액 1천 원 이상 시 할인 또는 적립 가능</li>
+     <li>최대 할인 가능 : 플라스틱 카드 이용 시 일 최대 10,000원 할인</li>
+     <li>최대 할인 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000원, SILVER 10,000원 할인</li>
+     <li>최대 적립 가능 : 플라스틱 카드 이용 시 일 최대 10,000P 적립</li>
+     <li>최대 적립 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000P, SILVER 10,000P 적립</li>
+     <li>결제 전 직원에게 T 멤버십 카드 제시</li>
+     <li>타 적립 및 쿠폰 동시 적용 불가</li>
+     <li>제외 매장 : 일부 점포(휴게소, 역사, 인샵, 특수매장 등) 제외 됩니다.</li>
+     <li>적립된 포인트는 ‘적립 예정’ 포인트로 표시되며, 결제일 1일 이후부터 사용 가능 포인트로 전환됩니다.</li>
+    </ul>
+   </div>
+  </div>
+ </dd>
+</dl>
+<dt>
+ 유의사항
+</dt>
+<dd>
+ <div class="notice">
+  <div class="explain-area pd-no">
+   <ul class="list-dot">
+    <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+    <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+    <li>횟수 제한 : 1일 1회 결제금액 1천 원 이상 시 할인 또는 적립 가능</li>
+    <li>최대 할인 가능 : 플라스틱 카드 이용 시 일 최대 10,000원 할인</li>
+    <li>최대 할인 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000원, SILVER 10,000원 할인</li>
+    <li>최대 적립 가능 : 플라스틱 카드 이용 시 일 최대 10,000P 적립</li>
+    <li>최대 적립 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000P, SILVER 10,000P 적립</li>
+    <li>결제 전 직원에게 T 멤버십 카드 제시</li>
+    <li>타 적립 및 쿠폰 동시 적용 불가</li>
+    <li>제외 매장 : 일부 점포(휴게소, 역사, 인샵, 특수매장 등) 제외 됩니다.</li>
+    <li>적립된 포인트는 ‘적립 예정’ 포인트로 표시되며, 결제일 1일 이후부터 사용 가능 포인트로 전환됩니다.</li>
+   </ul>
+  </div>
+ </div>
+</dd>
+<div class="notice">
+ <div class="explain-area pd-no">
+  <ul class="list-dot">
+   <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+   <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+   <li>횟수 제한 : 1일 1회 결제금액 1천 원 이상 시 할인 또는 적립 가능</li>
+   <li>최대 할인 가능 : 플라스틱 카드 이용 시 일 최대 10,000원 할인</li>
+   <li>최대 할인 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000원, SILVER 10,000원 할인</li>
+   <li>최대 적립 가능 : 플라스틱 카드 이용 시 일 최대 10,000P 적립</li>
+   <li>최대 적립 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000P, SILVER 10,000P 적립</li>
+   <li>결제 전 직원에게 T 멤버십 카드 제시</li>
+   <li>타 적립 및 쿠폰 동시 적용 불가</li>
+   <li>제외 매장 : 일부 점포(휴게소, 역사, 인샵, 특수매장 등) 제외 됩니다.</li>
+   <li>적립된 포인트는 ‘적립 예정’ 포인트로 표시되며, 결제일 1일 이후부터 사용 가능 포인트로 전환됩니다.</li>
+  </ul>
+ </div>
+</div>
+<div class="explain-area pd-no">
+ <ul class="list-dot">
+  <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+  <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+  <li>횟수 제한 : 1일 1회 결제금액 1천 원 이상 시 할인 또는 적립 가능</li>
+  <li>최대 할인 가능 : 플라스틱 카드 이용 시 일 최대 10,000원 할인</li>
+  <li>최대 할인 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000원, SILVER 10,000원 할인</li>
+  <li>최대 적립 가능 : 플라스틱 카드 이용 시 일 최대 10,000P 적립</li>
+  <li>최대 적립 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000P, SILVER 10,000P 적립</li>
+  <li>결제 전 직원에게 T 멤버십 카드 제시</li>
+  <li>타 적립 및 쿠폰 동시 적용 불가</li>
+  <li>제외 매장 : 일부 점포(휴게소, 역사, 인샵, 특수매장 등) 제외 됩니다.</li>
+  <li>적립된 포인트는 ‘적립 예정’ 포인트로 표시되며, 결제일 1일 이후부터 사용 가능 포인트로 전환됩니다.</li>
+ </ul>
+</div>
+<ul class="list-dot">
+ <li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+ <li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+ <li>횟수 제한 : 1일 1회 결제금액 1천 원 이상 시 할인 또는 적립 가능</li>
+ <li>최대 할인 가능 : 플라스틱 카드 이용 시 일 최대 10,000원 할인</li>
+ <li>최대 할인 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000원, SILVER 10,000원 할인</li>
+ <li>최대 적립 가능 : 플라스틱 카드 이용 시 일 최대 10,000P 적립</li>
+ <li>최대 적립 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000P, SILVER 10,000P 적립</li>
+ <li>결제 전 직원에게 T 멤버십 카드 제시</li>
+ <li>타 적립 및 쿠폰 동시 적용 불가</li>
+ <li>제외 매장 : 일부 점포(휴게소, 역사, 인샵, 특수매장 등) 제외 됩니다.</li>
+ <li>적립된 포인트는 ‘적립 예정’ 포인트로 표시되며, 결제일 1일 이후부터 사용 가능 포인트로 전환됩니다.</li>
+</ul>
+<li>할인 또는 적립 혜택을 받기 위해서는 반드시 직원에게 T 멤버십 App 내 일회용 바코드를 제시해야 합니다.</li>
+<li>일회용 바코드는 기존 T 멤버십 카드번호와는 달리 20분 단위로 변경되는 바코드를 의미합니다.</li>
+<li>횟수 제한 : 1일 1회 결제금액 1천 원 이상 시 할인 또는 적립 가능</li>
+<li>최대 할인 가능 : 플라스틱 카드 이용 시 일 최대 10,000원 할인</li>
+<li>최대 할인 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000원, SILVER 10,000원 할인</li>
+<li>최대 적립 가능 : 플라스틱 카드 이용 시 일 최대 10,000P 적립</li>
+<li>최대 적립 가능 : 모바일 카드 이용 시 일 최대 VIP/GOLD 20,000P, SILVER 10,000P 적립</li>
+<li>결제 전 직원에게 T 멤버십 카드 제시</li>
+<li>타 적립 및 쿠폰 동시 적용 불가</li>
+<li>제외 매장 : 일부 점포(휴게소, 역사, 인샵, 특수매장 등) 제외 됩니다.</li>
+<li>적립된 포인트는 ‘적립 예정’ 포인트로 표시되며, 결제일 1일 이후부터 사용 가능 포인트로 전환됩니다.</li>
+<dl>
+ <dt>
+  문의 및 상담
+ </dt>
+ <dd>
+  <ul class="list-dash">
+   <li>TEL : 080-731-2027</li>
+   <li>HOME : <a href="javascript:goHomePage('https://www.paris.co.kr/')">https://www.paris.co.kr/</a></li>
+  </ul>
+ </dd>
+</dl>
+<dt>
+ 문의 및 상담
+</dt>
+<dd>
+ <ul class="list-dash">
+  <li>TEL : 080-731-2027</li>
+  <li>HOME : <a href="javascript:goHomePage('https://www.paris.co.kr/')">https://www.paris.co.kr/</a></li>
+ </ul>
+</dd>
+<ul class="list-dash">
+ <li>TEL : 080-731-2027</li>
+ <li>HOME : <a href="javascript:goHomePage('https://www.paris.co.kr/')">https://www.paris.co.kr/</a></li>
+</ul>
+<li>TEL : 080-731-2027</li>
+<li>HOME : <a href="javascript:goHomePage('https://www.paris.co.kr/')">https://www.paris.co.kr/</a></li>
+<a href="javascript:goHomePage('https://www.paris.co.kr/')">https://www.paris.co.kr/</a>
+<div class="similar-area">
+ <div class="inr-wrap">
+  <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+  <ul class="benefit-list">
+   <li><a href="javascript:;" class="benefit-box" id="1121" data-title="파리크라상" data-idx="0" data-cate-id="53" data-cate-name="베이커리">
+     <div class="bnf-top">
+      <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635236220043.png" alt="파리크라상"> </span> <span class="sort">베이커리</span> <span class="brand">파리크라상</span>
+      <div class="badge-list">
+       <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+      </div>
+     </div>
+     <div class="bnf-info">
+      <dl class="dl-bnf">
+       <dt>
+        할인형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+        </div>
+       </dd>
+      </dl>
+      <dl class="dl-bnf">
+       <dt>
+        적립형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+        </div>
+       </dd>
+      </dl>
+     </div><span class="btn-round gra">자세히 보기</span> </a></li>
+   <li><a href="javascript:;" class="benefit-box" id="1151" data-title="빌리엔젤" data-idx="1" data-cate-id="53" data-cate-name="베이커리">
+     <div class="bnf-top">
+      <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202209/1663893303634.png" alt="빌리엔젤"> </span> <span class="sort">베이커리</span> <span class="brand">빌리엔젤</span>
+      <div class="badge-list">
+       <i class="badge-bg-radius skyBlue">할인</i>
+      </div>
+     </div>
+     <div class="bnf-info">
+      <dl class="dl-bnf">
+       <dt>
+        할인형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+        </div>
+       </dd>
+      </dl>
+      <dl class="dl-bnf">
+       <dt>
+        적립형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+        </div>
+       </dd>
+      </dl>
+     </div><span class="btn-round gra">자세히 보기</span> </a></li>
+   <li><a href="javascript:;" class="benefit-box" id="1084" data-title="뚜레쥬르" data-idx="2" data-cate-id="53" data-cate-name="베이커리">
+     <div class="bnf-top">
+      <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635148435539.png" alt="뚜레쥬르"> </span> <span class="sort">베이커리</span> <span class="brand">뚜레쥬르</span>
+      <div class="badge-list">
+       <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+      </div>
+     </div>
+     <div class="bnf-info">
+      <dl class="dl-bnf">
+       <dt>
+        할인형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150원 할인
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50원 할인
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+        </div>
+       </dd>
+      </dl>
+      <dl class="dl-bnf">
+       <dt>
+        적립형
+       </dt>
+       <dd>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150P 적립
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50P 적립
+        </div>
+        <div class="info">
+         <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+        </div>
+       </dd>
+      </dl>
+     </div><span class="btn-round gra">자세히 보기</span> </a></li>
+  </ul>
+ </div>
+</div>
+<div class="inr-wrap">
+ <h2>비슷한 혜택 브랜드</h2><input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+ <ul class="benefit-list">
+  <li><a href="javascript:;" class="benefit-box" id="1121" data-title="파리크라상" data-idx="0" data-cate-id="53" data-cate-name="베이커리">
+    <div class="bnf-top">
+     <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635236220043.png" alt="파리크라상"> </span> <span class="sort">베이커리</span> <span class="brand">파리크라상</span>
+     <div class="badge-list">
+      <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+     </div>
+    </div>
+    <div class="bnf-info">
+     <dl class="dl-bnf">
+      <dt>
+       할인형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+       </div>
+      </dd>
+     </dl>
+     <dl class="dl-bnf">
+      <dt>
+       적립형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+       </div>
+      </dd>
+     </dl>
+    </div><span class="btn-round gra">자세히 보기</span> </a></li>
+  <li><a href="javascript:;" class="benefit-box" id="1151" data-title="빌리엔젤" data-idx="1" data-cate-id="53" data-cate-name="베이커리">
+    <div class="bnf-top">
+     <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202209/1663893303634.png" alt="빌리엔젤"> </span> <span class="sort">베이커리</span> <span class="brand">빌리엔젤</span>
+     <div class="badge-list">
+      <i class="badge-bg-radius skyBlue">할인</i>
+     </div>
+    </div>
+    <div class="bnf-info">
+     <dl class="dl-bnf">
+      <dt>
+       할인형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+       </div>
+      </dd>
+     </dl>
+     <dl class="dl-bnf">
+      <dt>
+       적립형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+       </div>
+      </dd>
+     </dl>
+    </div><span class="btn-round gra">자세히 보기</span> </a></li>
+  <li><a href="javascript:;" class="benefit-box" id="1084" data-title="뚜레쥬르" data-idx="2" data-cate-id="53" data-cate-name="베이커리">
+    <div class="bnf-top">
+     <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635148435539.png" alt="뚜레쥬르"> </span> <span class="sort">베이커리</span> <span class="brand">뚜레쥬르</span>
+     <div class="badge-list">
+      <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+     </div>
+    </div>
+    <div class="bnf-info">
+     <dl class="dl-bnf">
+      <dt>
+       할인형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150원 할인
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50원 할인
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+       </div>
+      </dd>
+     </dl>
+     <dl class="dl-bnf">
+      <dt>
+       적립형
+      </dt>
+      <dd>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150P 적립
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50P 적립
+       </div>
+       <div class="info">
+        <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+       </div>
+      </dd>
+     </dl>
+    </div><span class="btn-round gra">자세히 보기</span> </a></li>
+ </ul>
+</div>
+<h2>비슷한 혜택 브랜드</h2>
+<input type="hidden" name="similarBrandSize" id="similarBrandSize" value="3">
+<ul class="benefit-list">
+ <li><a href="javascript:;" class="benefit-box" id="1121" data-title="파리크라상" data-idx="0" data-cate-id="53" data-cate-name="베이커리">
+   <div class="bnf-top">
+    <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635236220043.png" alt="파리크라상"> </span> <span class="sort">베이커리</span> <span class="brand">파리크라상</span>
+    <div class="badge-list">
+     <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+    </div>
+   </div>
+   <div class="bnf-info">
+    <dl class="dl-bnf">
+     <dt>
+      할인형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+      </div>
+     </dd>
+    </dl>
+    <dl class="dl-bnf">
+     <dt>
+      적립형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+      </div>
+     </dd>
+    </dl>
+   </div><span class="btn-round gra">자세히 보기</span> </a></li>
+ <li><a href="javascript:;" class="benefit-box" id="1151" data-title="빌리엔젤" data-idx="1" data-cate-id="53" data-cate-name="베이커리">
+   <div class="bnf-top">
+    <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202209/1663893303634.png" alt="빌리엔젤"> </span> <span class="sort">베이커리</span> <span class="brand">빌리엔젤</span>
+    <div class="badge-list">
+     <i class="badge-bg-radius skyBlue">할인</i>
+    </div>
+   </div>
+   <div class="bnf-info">
+    <dl class="dl-bnf">
+     <dt>
+      할인형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+      </div>
+     </dd>
+    </dl>
+    <dl class="dl-bnf">
+     <dt>
+      적립형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+      </div>
+     </dd>
+    </dl>
+   </div><span class="btn-round gra">자세히 보기</span> </a></li>
+ <li><a href="javascript:;" class="benefit-box" id="1084" data-title="뚜레쥬르" data-idx="2" data-cate-id="53" data-cate-name="베이커리">
+   <div class="bnf-top">
+    <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635148435539.png" alt="뚜레쥬르"> </span> <span class="sort">베이커리</span> <span class="brand">뚜레쥬르</span>
+    <div class="badge-list">
+     <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+    </div>
+   </div>
+   <div class="bnf-info">
+    <dl class="dl-bnf">
+     <dt>
+      할인형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150원 할인
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50원 할인
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+      </div>
+     </dd>
+    </dl>
+    <dl class="dl-bnf">
+     <dt>
+      적립형
+     </dt>
+     <dd>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150P 적립
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50P 적립
+      </div>
+      <div class="info">
+       <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+      </div>
+     </dd>
+    </dl>
+   </div><span class="btn-round gra">자세히 보기</span> </a></li>
+</ul>
+<li><a href="javascript:;" class="benefit-box" id="1121" data-title="파리크라상" data-idx="0" data-cate-id="53" data-cate-name="베이커리">
+  <div class="bnf-top">
+   <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635236220043.png" alt="파리크라상"> </span> <span class="sort">베이커리</span> <span class="brand">파리크라상</span>
+   <div class="badge-list">
+    <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+   </div>
+  </div>
+  <div class="bnf-info">
+   <dl class="dl-bnf">
+    <dt>
+     할인형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+     </div>
+    </dd>
+   </dl>
+   <dl class="dl-bnf">
+    <dt>
+     적립형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+     </div>
+    </dd>
+   </dl>
+  </div><span class="btn-round gra">자세히 보기</span> </a></li>
+<a href="javascript:;" class="benefit-box" id="1121" data-title="파리크라상" data-idx="0" data-cate-id="53" data-cate-name="베이커리">
+ <div class="bnf-top">
+  <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635236220043.png" alt="파리크라상"> </span> <span class="sort">베이커리</span> <span class="brand">파리크라상</span>
+  <div class="badge-list">
+   <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+  </div>
+ </div>
+ <div class="bnf-info">
+  <dl class="dl-bnf">
+   <dt>
+    할인형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+    </div>
+   </dd>
+  </dl>
+  <dl class="dl-bnf">
+   <dt>
+    적립형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+    </div>
+   </dd>
+  </dl>
+ </div><span class="btn-round gra">자세히 보기</span> </a>
+<div class="bnf-top">
+ <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635236220043.png" alt="파리크라상"> </span> <span class="sort">베이커리</span> <span class="brand">파리크라상</span>
+ <div class="badge-list">
+  <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+ </div>
+</div>
+<span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635236220043.png" alt="파리크라상"> </span>
+<img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635236220043.png" alt="파리크라상">
+<span class="sort">베이커리</span>
+<span class="brand">파리크라상</span>
+<div class="badge-list">
+ <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+</div>
+<i class="badge-bg-radius skyBlue">할인</i>
+<i class="badge-bg-radius pink">적립</i>
+<i class="badge-bg-radius skyBlue">사용</i>
+<div class="bnf-info">
+ <dl class="dl-bnf">
+  <dt>
+   할인형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+   </div>
+  </dd>
+ </dl>
+ <dl class="dl-bnf">
+  <dt>
+   적립형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+   </div>
+  </dd>
+ </dl>
+</div>
+<dl class="dl-bnf">
+ <dt>
+  할인형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+  </div>
+ </dd>
+</dl>
+<dt>
+ 할인형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100원 할인(모바일카드) / 천원당 50원 할인(플라스틱카드)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50원 할인 (모바일카드/플라스틱카드)
+</div>
+<span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<dl class="dl-bnf">
+ <dt>
+  적립형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+  </div>
+ </dd>
+</dl>
+<dt>
+ 적립형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 천원당 100P 적립(모바일카드) / 천원당 50P 적립(플라스틱카드)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 천원당 50P 적립 (모바일카드/플라스틱카드)
+</div>
+<span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<i class="badge-circle lite"><span class="blind">L</span></i>
+<span class="blind">L</span>
+<span class="btn-round gra">자세히 보기</span>
+<li><a href="javascript:;" class="benefit-box" id="1151" data-title="빌리엔젤" data-idx="1" data-cate-id="53" data-cate-name="베이커리">
+  <div class="bnf-top">
+   <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202209/1663893303634.png" alt="빌리엔젤"> </span> <span class="sort">베이커리</span> <span class="brand">빌리엔젤</span>
+   <div class="badge-list">
+    <i class="badge-bg-radius skyBlue">할인</i>
+   </div>
+  </div>
+  <div class="bnf-info">
+   <dl class="dl-bnf">
+    <dt>
+     할인형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+     </div>
+    </dd>
+   </dl>
+   <dl class="dl-bnf">
+    <dt>
+     적립형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+     </div>
+    </dd>
+   </dl>
+  </div><span class="btn-round gra">자세히 보기</span> </a></li>
+<a href="javascript:;" class="benefit-box" id="1151" data-title="빌리엔젤" data-idx="1" data-cate-id="53" data-cate-name="베이커리">
+ <div class="bnf-top">
+  <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202209/1663893303634.png" alt="빌리엔젤"> </span> <span class="sort">베이커리</span> <span class="brand">빌리엔젤</span>
+  <div class="badge-list">
+   <i class="badge-bg-radius skyBlue">할인</i>
+  </div>
+ </div>
+ <div class="bnf-info">
+  <dl class="dl-bnf">
+   <dt>
+    할인형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+    </div>
+   </dd>
+  </dl>
+  <dl class="dl-bnf">
+   <dt>
+    적립형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+    </div>
+   </dd>
+  </dl>
+ </div><span class="btn-round gra">자세히 보기</span> </a>
+<div class="bnf-top">
+ <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202209/1663893303634.png" alt="빌리엔젤"> </span> <span class="sort">베이커리</span> <span class="brand">빌리엔젤</span>
+ <div class="badge-list">
+  <i class="badge-bg-radius skyBlue">할인</i>
+ </div>
+</div>
+<span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202209/1663893303634.png" alt="빌리엔젤"> </span>
+<img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202209/1663893303634.png" alt="빌리엔젤">
+<span class="sort">베이커리</span>
+<span class="brand">빌리엔젤</span>
+<div class="badge-list">
+ <i class="badge-bg-radius skyBlue">할인</i>
+</div>
+<i class="badge-bg-radius skyBlue">할인</i>
+<div class="bnf-info">
+ <dl class="dl-bnf">
+  <dt>
+   할인형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+   </div>
+  </dd>
+ </dl>
+ <dl class="dl-bnf">
+  <dt>
+   적립형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+   </div>
+  </dd>
+ </dl>
+</div>
+<dl class="dl-bnf">
+ <dt>
+  할인형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+  </div>
+ </dd>
+</dl>
+<dt>
+ 할인형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<dl class="dl-bnf">
+ <dt>
+  적립형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+  </div>
+ </dd>
+</dl>
+<dt>
+ 적립형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 15% 할인
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<span class="btn-round gra">자세히 보기</span>
+<li><a href="javascript:;" class="benefit-box" id="1084" data-title="뚜레쥬르" data-idx="2" data-cate-id="53" data-cate-name="베이커리">
+  <div class="bnf-top">
+   <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635148435539.png" alt="뚜레쥬르"> </span> <span class="sort">베이커리</span> <span class="brand">뚜레쥬르</span>
+   <div class="badge-list">
+    <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+   </div>
+  </div>
+  <div class="bnf-info">
+   <dl class="dl-bnf">
+    <dt>
+     할인형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150원 할인
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50원 할인
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+     </div>
+    </dd>
+   </dl>
+   <dl class="dl-bnf">
+    <dt>
+     적립형
+    </dt>
+    <dd>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150P 적립
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50P 적립
+     </div>
+     <div class="info">
+      <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+     </div>
+    </dd>
+   </dl>
+  </div><span class="btn-round gra">자세히 보기</span> </a></li>
+<a href="javascript:;" class="benefit-box" id="1084" data-title="뚜레쥬르" data-idx="2" data-cate-id="53" data-cate-name="베이커리">
+ <div class="bnf-top">
+  <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635148435539.png" alt="뚜레쥬르"> </span> <span class="sort">베이커리</span> <span class="brand">뚜레쥬르</span>
+  <div class="badge-list">
+   <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+  </div>
+ </div>
+ <div class="bnf-info">
+  <dl class="dl-bnf">
+   <dt>
+    할인형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150원 할인
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50원 할인
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+    </div>
+   </dd>
+  </dl>
+  <dl class="dl-bnf">
+   <dt>
+    적립형
+   </dt>
+   <dd>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150P 적립
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50P 적립
+    </div>
+    <div class="info">
+     <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+    </div>
+   </dd>
+  </dl>
+ </div><span class="btn-round gra">자세히 보기</span> </a>
+<div class="bnf-top">
+ <span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635148435539.png" alt="뚜레쥬르"> </span> <span class="sort">베이커리</span> <span class="brand">뚜레쥬르</span>
+ <div class="badge-list">
+  <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+ </div>
+</div>
+<span class="logo"> <img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635148435539.png" alt="뚜레쥬르"> </span>
+<img src="https://cdn.sktmembership.co.kr/mps.app/catalogue/brand/202110/1635148435539.png" alt="뚜레쥬르">
+<span class="sort">베이커리</span>
+<span class="brand">뚜레쥬르</span>
+<div class="badge-list">
+ <i class="badge-bg-radius skyBlue">할인</i> <i class="badge-bg-radius pink">적립</i> <i class="badge-bg-radius skyBlue">사용</i>
+</div>
+<i class="badge-bg-radius skyBlue">할인</i>
+<i class="badge-bg-radius pink">적립</i>
+<i class="badge-bg-radius skyBlue">사용</i>
+<div class="bnf-info">
+ <dl class="dl-bnf">
+  <dt>
+   할인형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150원 할인
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50원 할인
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+   </div>
+  </dd>
+ </dl>
+ <dl class="dl-bnf">
+  <dt>
+   적립형
+  </dt>
+  <dd>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150P 적립
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50P 적립
+   </div>
+   <div class="info">
+    <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+   </div>
+  </dd>
+ </dl>
+</div>
+<dl class="dl-bnf">
+ <dt>
+  할인형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150원 할인
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50원 할인
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+  </div>
+ </dd>
+</dl>
+<dt>
+ 할인형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150원 할인
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50원 할인
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150원 할인
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50원 할인
+</div>
+<span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<dl class="dl-bnf">
+ <dt>
+  적립형
+ </dt>
+ <dd>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150P 적립
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50P 적립
+  </div>
+  <div class="info">
+   <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+  </div>
+ </dd>
+</dl>
+<dt>
+ 적립형
+</dt>
+<dd>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150P 적립
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50P 적립
+ </div>
+ <div class="info">
+  <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+ </div>
+</dd>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span> 1천원당 150P 적립
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span> 1천원당 50P 적립
+</div>
+<span class="badge-list"> <i class="badge-circle silver"><span class="blind">S</span></i> </span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<div class="info">
+ <span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span> 포인트 사용가능 (100%, 10P 단위)
+</div>
+<span class="badge-list"> <i class="badge-circle vip"><span class="blind">V</span></i><i class="badge-circle gold"><span class="blind">G</span></i><i class="badge-circle silver"><span class="blind">S</span></i><i class="badge-circle lite"><span class="blind">L</span></i> </span>
+<i class="badge-circle vip"><span class="blind">V</span></i>
+<span class="blind">V</span>
+<i class="badge-circle gold"><span class="blind">G</span></i>
+<span class="blind">G</span>
+<i class="badge-circle silver"><span class="blind">S</span></i>
+<span class="blind">S</span>
+<i class="badge-circle lite"><span class="blind">L</span></i>
+<span class="blind">L</span>
+<span class="btn-round gra">자세히 보기</span>
+<div id="footer" class="main-footer">
+ <a href="#" class="footer__go-top"><span class="hidden">상단으로 이동</span></a>
+ <div class="main-footer__top">
+  <div class="footer_cont">
+   <!-- 20230411 클래스명 변경 -->
+   <div class="bar-list">
+    <div class="bar-list__item">
+     <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+    </div><!-- 2023-05-23 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+    </div><!-- 2023-05-23 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+    </div><!-- 230515 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+    </div><!-- 230515 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+    </div><!-- 230515 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+    </div><!-- 230515 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+    </div><!-- 230515 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+    </div>
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+    </div><!-- 230515 수정 -->
+    <div class="bar-list__item">
+     <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+    </div><!-- 230515 수정 -->
+    <div class="bar-list__item">
+     <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+    </div>
+    <div class="bar-list__item">
+     <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+    </div>
+   </div>
+  </div>
+ </div>
+ <div class="main-footer__bottom">
+  <div class="footer_cont">
+   <!-- 20230411 클래스명 변경 -->
+   <div class="logo-list">
+    <div class="logo-list__item">
+     <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+       26년 연속 1위</span></a>
+    </div><!-- 2023-05-30 수정 -->
+    <div class="logo-list__item">
+     <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+       23년 연속 1위</span></a>
+    </div><!-- 20230508 수정 -->
+    <div class="logo-list__item">
+     <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+       25년 연속 1위</span></a>
+    </div><!-- 20230508 수정 -->
+    <div class="logo-list__item">
+     <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+    </div><!-- 20230508 수정 -->
+   </div>
+   <div class="footer__info-box width-auto">
+    <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+    <div class="column-box__item">
+     <div class="column-box__inner">
+      <div class="bar-list bar-list--narrow">
+       <div class="bar-list__item">
+        SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+        <br>
+        (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+       </div>
+       <hr class="bar-list--narrow bar-list--grey">
+       <div class="bar-list__item">
+        <strong>고객센터</strong>
+       </div>
+       <div class="bar-list__item">
+        대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+       </div><!-- 2023-05-23 수정 -->
+       <hr class="bar-list__line">
+       <div class="bar-list__item">
+        인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+       </div><!-- 2023-05-23 수정 -->
+       <div class="bar-list__item">
+        T 멤버십 마켓 : 1599-3377(유료)
+       </div><!-- 2023-05-23 수정 -->
+      </div>
+      <div class="bar-list bar-list--narrow bar-list--grey">
+       <div class="bar-list__item">
+        대표이사/사장 : 유영상
+       </div>
+       <div class="bar-list__item">
+        사업자등록번호 : 104-81-37225
+       </div>
+       <div class="bar-list__item">
+        판매허가번호 : 중구 02923호
+       </div>
+       <div class="bar-list__item">
+        <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+       </div>
+       <hr class="bar-list__line">
+       <div class="bar-list__item">
+        서울특별시 중구 을지로 65
+       </div>
+       <hr class="bar-list__line">
+       <div class="bar-list__item copyright">
+        COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+       </div>
+      </div>
+     </div>
+    </div>
+    <div class="column-box__item column-box__item--right">
+     <div class="column-box__inner">
+      <div class="site-list">
+       <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+       <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+        <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+        <div class="family-list" data-element="commonToggle__layer">
+         <div class="family-list__item">
+          <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+         </div><!-- 2023-05-30 수정 -->
+         <div class="family-list__item">
+          <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+         </div>
+         <div class="family-list__item">
+          <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+         </div>
+         <div class="family-list__item">
+          <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+         </div>
+         <div class="family-list__item">
+          <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+         </div>
+         <div class="family-list__item">
+          <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+         </div>
+         <div class="family-list__item">
+          <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+         </div>
+         <div class="family-list__item">
+          <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+         </div>
+         <div class="family-list__item">
+          <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+         </div>
+        </div>
+       </div>
+      </div>
+      <div class="social-list">
+       <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+ </div>
+</div>
+<a href="#" class="footer__go-top"><span class="hidden">상단으로 이동</span></a>
+<span class="hidden">상단으로 이동</span>
+<div class="main-footer__top">
+ <div class="footer_cont">
+  <!-- 20230411 클래스명 변경 -->
+  <div class="bar-list">
+   <div class="bar-list__item">
+    <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+   </div><!-- 2023-05-23 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+   </div><!-- 2023-05-23 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+   </div><!-- 230515 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+   </div><!-- 230515 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+   </div><!-- 230515 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+   </div><!-- 230515 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+   </div><!-- 230515 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+   </div>
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+   </div><!-- 230515 수정 -->
+   <div class="bar-list__item">
+    <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+   </div><!-- 230515 수정 -->
+   <div class="bar-list__item">
+    <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+   </div>
+   <div class="bar-list__item">
+    <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="footer_cont">
+ <!-- 20230411 클래스명 변경 -->
+ <div class="bar-list">
+  <div class="bar-list__item">
+   <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+  </div><!-- 2023-05-23 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+  </div><!-- 2023-05-23 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+  </div><!-- 230515 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+  </div><!-- 230515 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+  </div><!-- 230515 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+  </div><!-- 230515 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+  </div><!-- 230515 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+  </div>
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+  </div><!-- 230515 수정 -->
+  <div class="bar-list__item">
+   <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+  </div><!-- 230515 수정 -->
+  <div class="bar-list__item">
+   <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+  </div>
+  <div class="bar-list__item">
+   <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+  </div>
+ </div>
+</div>
+<div class="bar-list">
+ <div class="bar-list__item">
+  <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+ </div><!-- 2023-05-23 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+ </div><!-- 2023-05-23 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+ </div><!-- 230515 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+ </div><!-- 230515 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+ </div><!-- 230515 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+ </div><!-- 230515 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+ </div><!-- 230515 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+ </div>
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+ </div><!-- 230515 수정 -->
+ <div class="bar-list__item">
+  <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+ </div><!-- 230515 수정 -->
+ <div class="bar-list__item">
+  <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+ </div>
+ <div class="bar-list__item">
+  <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+ </div>
+</div>
+<div class="bar-list__item">
+ <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+</div>
+<a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=01&amp;_ga=2.158279546.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림">이용약관</a>
+<div class="bar-list__item">
+ <a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+</div>
+<a href="https://www.skt-id.co.kr/member/terms/termsInfo.do?chnlId=TWDT&amp;client_type=WEB&amp;stplTypCd=02&amp;_ga=2.162866300.1128860457.1678670796-865085407.1660869199" onclick="window.open(this.href,'','width=550,height=700,scrollbars=yes'); return false" target="_blank" title="새창열림"><strong>개인정보 처리방침</strong></a>
+<strong>개인정보 처리방침</strong>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4AT.html">T 멤버십 회원약관</a>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.1.html">T 우주 LITE 회원 약관</a>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.4T.html"><strong>멤버십 통합 개인정보처리방침</strong></a>
+<strong>멤버십 통합 개인정보처리방침</strong>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.1T.html">T 멤버십 전자상거래 이용약관</a>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.8T.2T.html"><strong>T 멤버십 전자상거래 개인정보 처리방침</strong></a>
+<strong>T 멤버십 전자상거래 개인정보 처리방침</strong>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.1.2.2T.1T.html"><strong>위치기반서비스 이용약관</strong></a>
+<strong>위치기반서비스 이용약관</strong>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/member_policy/UT2.2.html">책임의 한계와 법적고지</a>
+<div class="bar-list__item">
+ <a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+</div>
+<a href="https://www.tworld.co.kr/poc/html/util/common/UT10.3P.html" onclick="window.open(this.href,'','width=650,height=330,scrollbars=no'); return false" target="_blank" title="새창열림">이메일 무단 수집거부</a>
+<div class="bar-list__item">
+ <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+</div>
+<a href="https://cdn.sktmembership.co.kr/mps.pc/poc/footer/footer_pop.html" onclick="window.open(this.href,'','width=648,height=410,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>분쟁처리절차</strong></a>
+<strong>분쟁처리절차</strong>
+<div class="bar-list__item">
+ <a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+</div>
+<a href="https://cdn.sktmembership.co.kr/mps.pc/poc/html/recommend/pop_partnership.html" onclick="window.open(this.href,'','width=648,height=650,scrollbars=no'); return false" target="_blank" title="새창열림"><strong>T 멤버십 제휴 제안</strong></a>
+<strong>T 멤버십 제휴 제안</strong>
+<div class="main-footer__bottom">
+ <div class="footer_cont">
+  <!-- 20230411 클래스명 변경 -->
+  <div class="logo-list">
+   <div class="logo-list__item">
+    <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+      26년 연속 1위</span></a>
+   </div><!-- 2023-05-30 수정 -->
+   <div class="logo-list__item">
+    <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+      23년 연속 1위</span></a>
+   </div><!-- 20230508 수정 -->
+   <div class="logo-list__item">
+    <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+      25년 연속 1위</span></a>
+   </div><!-- 20230508 수정 -->
+   <div class="logo-list__item">
+    <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+   </div><!-- 20230508 수정 -->
+  </div>
+  <div class="footer__info-box width-auto">
+   <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+   <div class="column-box__item">
+    <div class="column-box__inner">
+     <div class="bar-list bar-list--narrow">
+      <div class="bar-list__item">
+       SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+       <br>
+       (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+      </div>
+      <hr class="bar-list--narrow bar-list--grey">
+      <div class="bar-list__item">
+       <strong>고객센터</strong>
+      </div>
+      <div class="bar-list__item">
+       대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+      </div><!-- 2023-05-23 수정 -->
+      <hr class="bar-list__line">
+      <div class="bar-list__item">
+       인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+      </div><!-- 2023-05-23 수정 -->
+      <div class="bar-list__item">
+       T 멤버십 마켓 : 1599-3377(유료)
+      </div><!-- 2023-05-23 수정 -->
+     </div>
+     <div class="bar-list bar-list--narrow bar-list--grey">
+      <div class="bar-list__item">
+       대표이사/사장 : 유영상
+      </div>
+      <div class="bar-list__item">
+       사업자등록번호 : 104-81-37225
+      </div>
+      <div class="bar-list__item">
+       판매허가번호 : 중구 02923호
+      </div>
+      <div class="bar-list__item">
+       <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+      </div>
+      <hr class="bar-list__line">
+      <div class="bar-list__item">
+       서울특별시 중구 을지로 65
+      </div>
+      <hr class="bar-list__line">
+      <div class="bar-list__item copyright">
+       COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+      </div>
+     </div>
+    </div>
+   </div>
+   <div class="column-box__item column-box__item--right">
+    <div class="column-box__inner">
+     <div class="site-list">
+      <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+      <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+       <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+       <div class="family-list" data-element="commonToggle__layer">
+        <div class="family-list__item">
+         <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+        </div><!-- 2023-05-30 수정 -->
+        <div class="family-list__item">
+         <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+        </div>
+        <div class="family-list__item">
+         <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+        </div>
+        <div class="family-list__item">
+         <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+        </div>
+        <div class="family-list__item">
+         <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+        </div>
+        <div class="family-list__item">
+         <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+        </div>
+        <div class="family-list__item">
+         <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+        </div>
+        <div class="family-list__item">
+         <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+        </div>
+        <div class="family-list__item">
+         <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+        </div>
+       </div>
+      </div>
+     </div>
+     <div class="social-list">
+      <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+     </div>
+    </div>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="footer_cont">
+ <!-- 20230411 클래스명 변경 -->
+ <div class="logo-list">
+  <div class="logo-list__item">
+   <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+     26년 연속 1위</span></a>
+  </div><!-- 2023-05-30 수정 -->
+  <div class="logo-list__item">
+   <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+     23년 연속 1위</span></a>
+  </div><!-- 20230508 수정 -->
+  <div class="logo-list__item">
+   <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+     25년 연속 1위</span></a>
+  </div><!-- 20230508 수정 -->
+  <div class="logo-list__item">
+   <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+  </div><!-- 20230508 수정 -->
+ </div>
+ <div class="footer__info-box width-auto">
+  <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+  <div class="column-box__item">
+   <div class="column-box__inner">
+    <div class="bar-list bar-list--narrow">
+     <div class="bar-list__item">
+      SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+      <br>
+      (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+     </div>
+     <hr class="bar-list--narrow bar-list--grey">
+     <div class="bar-list__item">
+      <strong>고객센터</strong>
+     </div>
+     <div class="bar-list__item">
+      대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+     </div><!-- 2023-05-23 수정 -->
+     <hr class="bar-list__line">
+     <div class="bar-list__item">
+      인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+     </div><!-- 2023-05-23 수정 -->
+     <div class="bar-list__item">
+      T 멤버십 마켓 : 1599-3377(유료)
+     </div><!-- 2023-05-23 수정 -->
+    </div>
+    <div class="bar-list bar-list--narrow bar-list--grey">
+     <div class="bar-list__item">
+      대표이사/사장 : 유영상
+     </div>
+     <div class="bar-list__item">
+      사업자등록번호 : 104-81-37225
+     </div>
+     <div class="bar-list__item">
+      판매허가번호 : 중구 02923호
+     </div>
+     <div class="bar-list__item">
+      <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+     </div>
+     <hr class="bar-list__line">
+     <div class="bar-list__item">
+      서울특별시 중구 을지로 65
+     </div>
+     <hr class="bar-list__line">
+     <div class="bar-list__item copyright">
+      COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+     </div>
+    </div>
+   </div>
+  </div>
+  <div class="column-box__item column-box__item--right">
+   <div class="column-box__inner">
+    <div class="site-list">
+     <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+     <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+      <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+      <div class="family-list" data-element="commonToggle__layer">
+       <div class="family-list__item">
+        <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+       </div><!-- 2023-05-30 수정 -->
+       <div class="family-list__item">
+        <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+       </div>
+       <div class="family-list__item">
+        <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+       </div>
+       <div class="family-list__item">
+        <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+       </div>
+       <div class="family-list__item">
+        <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+       </div>
+       <div class="family-list__item">
+        <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+       </div>
+       <div class="family-list__item">
+        <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+       </div>
+       <div class="family-list__item">
+        <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+       </div>
+       <div class="family-list__item">
+        <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+       </div>
+      </div>
+     </div>
+    </div>
+    <div class="social-list">
+     <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+    </div>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="logo-list">
+ <div class="logo-list__item">
+  <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+    26년 연속 1위</span></a>
+ </div><!-- 2023-05-30 수정 -->
+ <div class="logo-list__item">
+  <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+    23년 연속 1위</span></a>
+ </div><!-- 20230508 수정 -->
+ <div class="logo-list__item">
+  <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+    25년 연속 1위</span></a>
+ </div><!-- 20230508 수정 -->
+ <div class="logo-list__item">
+  <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+ </div><!-- 20230508 수정 -->
+</div>
+<div class="logo-list__item">
+ <a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+   26년 연속 1위</span></a>
+</div>
+<a href="https://news.sktelecom.com/195609" class="icon icon-ncsi" target="_blank" title="새 창 열림"><span>국가고객만족도<br>
+  26년 연속 1위</span></a>
+<span>국가고객만족도<br>
+ 26년 연속 1위</span>
+<br>
+<div class="logo-list__item">
+ <a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+   23년 연속 1위</span></a>
+</div>
+<a href="https://news.sktelecom.com/179373" class="icon icon-sqi" target="_blank" title="새 창 열림"><span>한국서비스품질지수<br>
+  23년 연속 1위</span></a>
+<span>한국서비스품질지수<br>
+ 23년 연속 1위</span>
+<br>
+<div class="logo-list__item">
+ <a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+   25년 연속 1위</span></a>
+</div>
+<a href="https://news.sktelecom.com/182096" class="icon icon-kcsi" target="_blank" title="새 창 열림"><span>한국산업고객만족도<br>
+  25년 연속 1위</span></a>
+<span>한국산업고객만족도<br>
+ 25년 연속 1위</span>
+<br>
+<div class="logo-list__item">
+ <a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+</div>
+<a href="https://wiseuser.go.kr/usermain.do" class="icon icon-wiseuser" target="_blank" title="새 창 열림"><span>와이즈유저</span></a>
+<span>와이즈유저</span>
+<div class="footer__info-box width-auto">
+ <!-- 2023-05-23 / class명 변경 (footer__info-box)-->
+ <div class="column-box__item">
+  <div class="column-box__inner">
+   <div class="bar-list bar-list--narrow">
+    <div class="bar-list__item">
+     SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+     <br>
+     (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+    </div>
+    <hr class="bar-list--narrow bar-list--grey">
+    <div class="bar-list__item">
+     <strong>고객센터</strong>
+    </div>
+    <div class="bar-list__item">
+     대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+    </div><!-- 2023-05-23 수정 -->
+    <hr class="bar-list__line">
+    <div class="bar-list__item">
+     인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+    </div><!-- 2023-05-23 수정 -->
+    <div class="bar-list__item">
+     T 멤버십 마켓 : 1599-3377(유료)
+    </div><!-- 2023-05-23 수정 -->
+   </div>
+   <div class="bar-list bar-list--narrow bar-list--grey">
+    <div class="bar-list__item">
+     대표이사/사장 : 유영상
+    </div>
+    <div class="bar-list__item">
+     사업자등록번호 : 104-81-37225
+    </div>
+    <div class="bar-list__item">
+     판매허가번호 : 중구 02923호
+    </div>
+    <div class="bar-list__item">
+     <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+    </div>
+    <hr class="bar-list__line">
+    <div class="bar-list__item">
+     서울특별시 중구 을지로 65
+    </div>
+    <hr class="bar-list__line">
+    <div class="bar-list__item copyright">
+     COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+    </div>
+   </div>
+  </div>
+ </div>
+ <div class="column-box__item column-box__item--right">
+  <div class="column-box__inner">
+   <div class="site-list">
+    <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+    <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+     <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+     <div class="family-list" data-element="commonToggle__layer">
+      <div class="family-list__item">
+       <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+      </div><!-- 2023-05-30 수정 -->
+      <div class="family-list__item">
+       <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+      </div>
+      <div class="family-list__item">
+       <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+      </div>
+      <div class="family-list__item">
+       <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+      </div>
+      <div class="family-list__item">
+       <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+      </div>
+      <div class="family-list__item">
+       <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+      </div>
+      <div class="family-list__item">
+       <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+      </div>
+      <div class="family-list__item">
+       <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+      </div>
+      <div class="family-list__item">
+       <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+      </div>
+     </div>
+    </div>
+   </div>
+   <div class="social-list">
+    <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+   </div>
+  </div>
+ </div>
+</div>
+<div class="column-box__item">
+ <div class="column-box__inner">
+  <div class="bar-list bar-list--narrow">
+   <div class="bar-list__item">
+    SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+    <br>
+    (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+   </div>
+   <hr class="bar-list--narrow bar-list--grey">
+   <div class="bar-list__item">
+    <strong>고객센터</strong>
+   </div>
+   <div class="bar-list__item">
+    대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+   </div><!-- 2023-05-23 수정 -->
+   <hr class="bar-list__line">
+   <div class="bar-list__item">
+    인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+   </div><!-- 2023-05-23 수정 -->
+   <div class="bar-list__item">
+    T 멤버십 마켓 : 1599-3377(유료)
+   </div><!-- 2023-05-23 수정 -->
+  </div>
+  <div class="bar-list bar-list--narrow bar-list--grey">
+   <div class="bar-list__item">
+    대표이사/사장 : 유영상
+   </div>
+   <div class="bar-list__item">
+    사업자등록번호 : 104-81-37225
+   </div>
+   <div class="bar-list__item">
+    판매허가번호 : 중구 02923호
+   </div>
+   <div class="bar-list__item">
+    <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+   </div>
+   <hr class="bar-list__line">
+   <div class="bar-list__item">
+    서울특별시 중구 을지로 65
+   </div>
+   <hr class="bar-list__line">
+   <div class="bar-list__item copyright">
+    COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+   </div>
+  </div>
+ </div>
+</div>
+<div class="column-box__inner">
+ <div class="bar-list bar-list--narrow">
+  <div class="bar-list__item">
+   SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+   <br>
+   (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+  </div>
+  <hr class="bar-list--narrow bar-list--grey">
+  <div class="bar-list__item">
+   <strong>고객센터</strong>
+  </div>
+  <div class="bar-list__item">
+   대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+  </div><!-- 2023-05-23 수정 -->
+  <hr class="bar-list__line">
+  <div class="bar-list__item">
+   인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+  </div><!-- 2023-05-23 수정 -->
+  <div class="bar-list__item">
+   T 멤버십 마켓 : 1599-3377(유료)
+  </div><!-- 2023-05-23 수정 -->
+ </div>
+ <div class="bar-list bar-list--narrow bar-list--grey">
+  <div class="bar-list__item">
+   대표이사/사장 : 유영상
+  </div>
+  <div class="bar-list__item">
+   사업자등록번호 : 104-81-37225
+  </div>
+  <div class="bar-list__item">
+   판매허가번호 : 중구 02923호
+  </div>
+  <div class="bar-list__item">
+   <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+  </div>
+  <hr class="bar-list__line">
+  <div class="bar-list__item">
+   서울특별시 중구 을지로 65
+  </div>
+  <hr class="bar-list__line">
+  <div class="bar-list__item copyright">
+   COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+  </div>
+ </div>
+</div>
+<div class="bar-list bar-list--narrow">
+ <div class="bar-list__item">
+  SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+  <br>
+  (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+ </div>
+ <hr class="bar-list--narrow bar-list--grey">
+ <div class="bar-list__item">
+  <strong>고객센터</strong>
+ </div>
+ <div class="bar-list__item">
+  대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+ </div><!-- 2023-05-23 수정 -->
+ <hr class="bar-list__line">
+ <div class="bar-list__item">
+  인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+ </div><!-- 2023-05-23 수정 -->
+ <div class="bar-list__item">
+  T 멤버십 마켓 : 1599-3377(유료)
+ </div><!-- 2023-05-23 수정 -->
+</div>
+<div class="bar-list__item">
+ SK텔레콤㈜는 통신판매중개자로서 본 멤버십 사이트에서 제 3자가 판매하는 상품 및 거래에 대해 일체 책임을 지지 않습니다. 
+ <br>
+ (SK텔레콤이 직접 판매하는 일부 상품은 제외)
+</div>
+<br>
+<hr class="bar-list--narrow bar-list--grey">
+<div class="bar-list__item">
+ <strong>고객센터</strong>
+</div>
+<strong>고객센터</strong>
+<div class="bar-list__item">
+ 대표 : 휴대폰 국번없이 114(무료) 또는 080-011-6000(무료), 국번없이 1599-0011(유료)
+</div>
+<hr class="bar-list__line">
+<div class="bar-list__item">
+ 인터넷/집전화 : 080-816-2000(무료) 또는 1600-2000(유료)
+</div>
+<div class="bar-list__item">
+ T 멤버십 마켓 : 1599-3377(유료)
+</div>
+<div class="bar-list bar-list--narrow bar-list--grey">
+ <div class="bar-list__item">
+  대표이사/사장 : 유영상
+ </div>
+ <div class="bar-list__item">
+  사업자등록번호 : 104-81-37225
+ </div>
+ <div class="bar-list__item">
+  판매허가번호 : 중구 02923호
+ </div>
+ <div class="bar-list__item">
+  <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+ </div>
+ <hr class="bar-list__line">
+ <div class="bar-list__item">
+  서울특별시 중구 을지로 65
+ </div>
+ <hr class="bar-list__line">
+ <div class="bar-list__item copyright">
+  COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+ </div>
+</div>
+<div class="bar-list__item">
+ 대표이사/사장 : 유영상
+</div>
+<div class="bar-list__item">
+ 사업자등록번호 : 104-81-37225
+</div>
+<div class="bar-list__item">
+ 판매허가번호 : 중구 02923호
+</div>
+<div class="bar-list__item">
+ <a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+</div>
+<a href="http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1048137225" class="underline" target="_blank" title="새 창 열림">사업자정보확인</a>
+<hr class="bar-list__line">
+<div class="bar-list__item">
+ 서울특별시 중구 을지로 65
+</div>
+<hr class="bar-list__line">
+<div class="bar-list__item copyright">
+ COPYRIGHT © SK TELECOM CO., LTD. ALL RIGHTS RESERVED.
+</div>
+<div class="column-box__item column-box__item--right">
+ <div class="column-box__inner">
+  <div class="site-list">
+   <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+   <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+    <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+    <div class="family-list" data-element="commonToggle__layer">
+     <div class="family-list__item">
+      <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+     </div><!-- 2023-05-30 수정 -->
+     <div class="family-list__item">
+      <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+     </div>
+     <div class="family-list__item">
+      <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+     </div>
+     <div class="family-list__item">
+      <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+     </div>
+     <div class="family-list__item">
+      <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+     </div>
+     <div class="family-list__item">
+      <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+     </div>
+     <div class="family-list__item">
+      <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+     </div>
+     <div class="family-list__item">
+      <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+     </div>
+     <div class="family-list__item">
+      <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+     </div>
+    </div>
+   </div>
+  </div>
+  <div class="social-list">
+   <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+  </div>
+ </div>
+</div>
+<div class="column-box__inner">
+ <div class="site-list">
+  <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+  <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+   <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+   <div class="family-list" data-element="commonToggle__layer">
+    <div class="family-list__item">
+     <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+    </div><!-- 2023-05-30 수정 -->
+    <div class="family-list__item">
+     <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+    </div>
+    <div class="family-list__item">
+     <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+    </div>
+    <div class="family-list__item">
+     <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+    </div>
+    <div class="family-list__item">
+     <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+    </div>
+    <div class="family-list__item">
+     <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+    </div>
+    <div class="family-list__item">
+     <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+    </div>
+    <div class="family-list__item">
+     <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+    </div>
+    <div class="family-list__item">
+     <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+    </div>
+   </div>
+  </div>
+ </div>
+ <div class="social-list">
+  <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+ </div>
+</div>
+<div class="site-list">
+ <a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+ <div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+  <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+  <div class="family-list" data-element="commonToggle__layer">
+   <div class="family-list__item">
+    <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+   </div><!-- 2023-05-30 수정 -->
+   <div class="family-list__item">
+    <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+   </div>
+   <div class="family-list__item">
+    <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+   </div>
+   <div class="family-list__item">
+    <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+   </div>
+   <div class="family-list__item">
+    <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+   </div>
+   <div class="family-list__item">
+    <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+   </div>
+   <div class="family-list__item">
+    <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+   </div>
+   <div class="family-list__item">
+    <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+   </div>
+   <div class="family-list__item">
+    <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+   </div>
+  </div>
+ </div>
+</div>
+<a href="https://www.tworld.co.kr/poc/eng/html/EN.html" target="_blank" title="새 창 열림" class="site-list__eng"><span>ENG</span></a>
+<span>ENG</span>
+<div class="site-list__family" data-element="commonToggle" data-option="{&quot;type&quot;: &quot;click&quot;}">
+ <!-- 2023-05-23 data-option='{"type": "click"}' 추가 --> <button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+ <div class="family-list" data-element="commonToggle__layer">
+  <div class="family-list__item">
+   <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+  </div><!-- 2023-05-30 수정 -->
+  <div class="family-list__item">
+   <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+  </div>
+  <div class="family-list__item">
+   <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+  </div>
+  <div class="family-list__item">
+   <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+  </div>
+  <div class="family-list__item">
+   <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+  </div>
+  <div class="family-list__item">
+   <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+  </div>
+  <div class="family-list__item">
+   <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+  </div>
+  <div class="family-list__item">
+   <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+  </div>
+  <div class="family-list__item">
+   <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+  </div>
+ </div>
+</div>
+<button type="button" class="family-button" data-element="commonToggle__button">Family Site</button>
+<div class="family-list" data-element="commonToggle__layer">
+ <div class="family-list__item">
+  <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+ </div><!-- 2023-05-30 수정 -->
+ <div class="family-list__item">
+  <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+ </div>
+ <div class="family-list__item">
+  <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+ </div>
+ <div class="family-list__item">
+  <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+ </div>
+ <div class="family-list__item">
+  <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+ </div>
+ <div class="family-list__item">
+  <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+ </div>
+ <div class="family-list__item">
+  <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+ </div>
+ <div class="family-list__item">
+  <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+ </div>
+ <div class="family-list__item">
+  <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+ </div>
+</div>
+<div class="family-list__item">
+ <a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+</div>
+<a href="http://b2b.tworld.co.kr" target="_blank" title="새 창 열림">T world Biz</a>
+<div class="family-list__item">
+ <a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+</div>
+<a href="http://www.sktelecom.com/" target="_blank" title="새 창 열림">SK Telecom</a>
+<div class="family-list__item">
+ <a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+</div>
+<a href="http://www.skbroadband.com/Main.do" target="_blank" title="새 창 열림">SK 브로드밴드</a>
+<div class="family-list__item">
+ <a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+</div>
+<a href="http://www.sksports.net/" target="_blank" title="새 창 열림">SK 스포츠단</a>
+<div class="family-list__item">
+ <a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+</div>
+<a href="http://ttogether.sktelecom.com/" target="_blank" title="새 창 열림">T together</a>
+<div class="family-list__item">
+ <a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+</div>
+<a href="http://www.twifi.co.kr" target="_blank" title="새 창 열림">T wifi zone</a>
+<div class="family-list__item">
+ <a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+</div>
+<a href="https://partneron.sktelecom.com/bp/main.do" target="_blank" title="새 창 열림">파트너온</a>
+<div class="family-list__item">
+ <a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+</div>
+<a href="http://www.nugu.co.kr/ " target="_blank" title="새 창 열림">NUGU </a>
+<div class="family-list__item">
+ <a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+</div>
+<a href="https://www.skshieldus.com/kor/index.do" target="_blank" title="새 창 열림">SK쉴더스</a>
+<div class="social-list">
+ <a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a> <a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a> <a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a> <a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a> <a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a> <a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+</div>
+<a href="https://twitter.com/Sktelecom" class="social-list__item icon icon-twitter" target="_blank" title="새 창 열림"><span>twitter</span></a>
+<span>twitter</span>
+<a href="https://www.facebook.com/sktelecom/" class="social-list__item icon icon-facebook" target="_blank" title="새 창 열림"><span>Facebook</span></a>
+<span>Facebook</span>
+<a href="https://news.sktelecom.com/" class="social-list__item icon icon-blog" target="_blank" title="새 창 열림"><span>Blog</span></a>
+<span>Blog</span>
+<a href="https://www.youtube.com/user/TworldTV" class="social-list__item icon icon-youtube" target="_blank" title="새 창 열림"><span>YouTube</span></a>
+<span>YouTube</span>
+<a href="https://story.kakao.com/ch/sktelecom" class="social-list__item icon icon-kakao" target="_blank" title="새 창 열림"><span>Kakao Story</span></a>
+<span>Kakao Story</span>
+<a href="https://www.instagram.com/sktelecom/" class="social-list__item icon icon-instagram" target="_blank" title="새 창 열림"><span>Instagram</span></a>
+<span>Instagram</span>
+<script type="text/javascript" src="/js/benefitbrand/MPW_D001_P03-f38ad4ae8f7e63be2335a3a34ed7a5af.js"></script>
+<div class="toast01" data-toast="toastContainer" data-y="bottom" data-duration="800" data-pos="20" data-timer="3000">
+ <span id="toastContainer"></span>
+</div>
+<span id="toastContainer"></span>
+<div class="loadingbar-area"></div>

--- a/src/test/java/com/cndinfo/service/MembershipServiceTest.java
+++ b/src/test/java/com/cndinfo/service/MembershipServiceTest.java
@@ -13,11 +13,35 @@ public class MembershipServiceTest {
 	@Test
 	public void sktTest() throws IOException {
 		
-		String url = "https://sktmembership.tworld.co.kr/mps/pc-bff/benefitbrand/list-tab1.do";
+//		String url = "https://sktmembership.tworld.co.kr/mps/pc-bff/benefitbrand/list-tab1.do";
+//		String url = "https://sktmembership.tworld.co.kr/mps/pc-bff/benefitbrand/detail.do?brandId=998";
+		String url = "https://sktmembership.tworld.co.kr/mps/pc-bff/benefitbrand/detail.do?brandId=1053";
 		
 		Document doc = Jsoup.connect(url).get();
 		
-		System.out.println(doc.getAllElements());
+//		String fileName = "./docs/MembershipTest/SKTTest.html";
+//		String fileName = "./docs/MembershipTest/SKTTest2.html";
+		
+//		BufferedWriter bw = new BufferedWriter(new FileWriter(fileName));
+		
+		String[] temp = doc.getElementById("sel-list").toString().split("\n");
+//		List<Integer> id_list = new ArrayList<>();
+		
+		// 하나의 브랜드에서 카테고리 id를 제외하고 브랜드 별 id 뽑아내기
+		for(int i=1; i<temp.length; i++) {
+			int start_idx = temp[i].indexOf("=") + 2;
+			int end_idx = start_idx;
+			while(true) {
+				end_idx++;
+				if(temp[i].charAt(end_idx) == '\"') {
+					System.out.println(temp[i].substring(start_idx, end_idx));
+					break;
+				}
+			}
+		}
+		
+//		bw.write(doc.getAllElements().toString());
+//		bw.close();
 	}
 
 }


### PR DESCRIPTION
DataBase 페이징 처리 때문에 하나의 url에서 모든 정보를 가져오지 못함.
그렇기 때문에 하나의 브랜드 선택 후 해당 url을 통해 크롤링한 후 브랜드 별 id 뽑아내도록 하였음.. id별로 url을 만들어 상세 혜택을 가져와 DataBase에 넣는 작업을 해야함. --> 해당 작업은 초기 한 번만 진행하면 되지만 100여 개의 브랜드를 크롤링 해야 함. ( 추가로, Membership 혜택에 대한 Table 설계를 진행해야 함. 브랜드 종류를 저장할 Table과 브랜드의 상세 혜택을 저장할 Table끼리 브랜드명을 FK로 관계를 맺고 상세 혜택은 등급별로 1 row 씩 저장하도록 하는 방식 생각 중 )

See Also : #8